### PR TITLE
feat(naming): rewrite package machine symbols to readable calls

### DIFF
--- a/context.md
+++ b/context.md
@@ -194,6 +194,7 @@ Current scope:
 - pool target symbol synthesis now also emits deterministic `package_<pkg>_<Owner>_<method>` names for `package:*` library targets, improving generic direct-call replacement in app/dependency code paths
 - symbol merge precedence now upgrades heuristic canonical names (`dart_*`, `flutter_*`, `package_*`) to stronger external symbols when both map to the same VA, reducing synthetic call names when symbol maps/ELFs are provided
 - generic symbol detection now also covers common tool-generated placeholders (`FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`) so deterministic semantic/external names can replace them
+- decompiler call intent now rewrites canonical package-machine symbols (`package_<pkg>_<Owner>_<method>`) into readable `pkg.Owner.method(...)` call paths and emits matching `package:<...>` semantic comments
 - Dart patch-library semantic naming now includes patch module stems when available (for example `dart:core-patch/bool_patch.dart` -> `dart.core_patch.bool_patch.*`) to reduce ambiguous `dart.core_patch.*` callsites
 - selector coverage now includes additional standard families such as `Navigator.pushNamed` and `List.removeAt`, improving deterministic semantic rewrites on real samples
 - selector coverage also includes internal/std selector forms such as `match_end_index` -> `dart.core.Match.end`

--- a/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
+++ b/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
@@ -33,6 +33,10 @@ pub(super) fn infer_call_intent(call_name: &str) -> Option<String> {
         return Some(tag);
     }
 
+    if let Some(tag) = infer_package_intent(call_name) {
+        return Some(tag);
+    }
+
     if lower.starts_with("vm_runtime_") {
         let name = lower.trim_start_matches("vm_runtime_");
         if !name.is_empty() {
@@ -91,6 +95,29 @@ fn infer_flutter_framework_intent(call_name: &str) -> Option<String> {
     ))
 }
 
+fn infer_package_intent(call_name: &str) -> Option<String> {
+    if !call_name.to_ascii_lowercase().starts_with("package_") {
+        return None;
+    }
+    let mut parts = call_name.split('_');
+    let head = parts.next().unwrap_or_default();
+    if !head.eq_ignore_ascii_case("package") {
+        return None;
+    }
+    let pkg = parts.next()?.trim();
+    let owner = parts.next()?.trim();
+    let method = parts.collect::<Vec<_>>().join("_");
+    if pkg.is_empty() || owner.is_empty() || method.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "package:{}.{}.{}",
+        pkg.to_ascii_lowercase(),
+        owner,
+        method
+    ))
+}
+
 pub(super) fn readable_call_name_from_intent(
     call_name: &str,
     intent: Option<&str>,
@@ -107,6 +134,7 @@ pub(super) fn readable_call_name_from_intent(
         lower == "dispatchtarget" || lower == "cachedtarget" || lower.starts_with("indirecttarget");
     let known_machine_name = lower.starts_with("dart_")
         || lower.starts_with("flutter_")
+        || lower.starts_with("package_")
         || lower.starts_with("vm_runtime_")
         || lower.starts_with("native_libc_")
         || lower.starts_with("native_android_log_");

--- a/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
+++ b/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
@@ -1112,6 +1112,49 @@ fn annotates_framework_from_pool_selector_when_call_name_is_generic() {
 }
 
 #[test]
+fn annotates_package_call_intents_from_machine_symbol_names() {
+    let ir = FunctionIr {
+        function_id: 26,
+        name: "packageCalls".to_string(),
+        entry_va: 0xfb00,
+        blocks: vec![BasicBlock {
+            id: 0,
+            start_va: 0xfb00,
+            instrs: vec![
+                LlirInstr {
+                    va: 0xfb00,
+                    op: IROp::Call,
+                    src: "bl #0x6300".to_string(),
+                    target: "#0x6300".to_string(),
+                },
+                LlirInstr {
+                    va: 0xfb04,
+                    op: IROp::Return,
+                    src: "ret".to_string(),
+                    target: String::new(),
+                },
+            ],
+            succs: Vec::new(),
+            preds: Vec::new(),
+        }],
+    };
+
+    let mut symbols = HashMap::new();
+    symbols.insert(
+        0x6300,
+        "package_spotube_ConnectService_executeCommandAsync".to_string(),
+    );
+    let artifact = emit_pseudocode(&ir, &symbols);
+    assert!(
+        artifact
+            .source
+            .contains("spotube.ConnectService.executeCommandAsync(receiver, param1, param2, param3); // package:spotube.ConnectService.executeCommandAsync, was: package_spotube_ConnectService_executeCommandAsync"),
+        "missing package call intent annotation:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
 fn annotates_flutter_scheduler_selector_from_pool_string() {
     let ir = FunctionIr {
         function_id: 26,

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -90,8 +90,9 @@ sequenceDiagram
 - auto-generated disassembler names such as `FUN_<hex>`, `nullsub_*`, `loc_*`, and `off_*` are also treated as generic placeholders during merge
 - pool target metadata now also emits deterministic `package_<pkg>_<Owner>_<method>` symbols for `package:*` libraries (not only `dart:*`/`package:flutter/*`)
 - when stronger external names are available for the same VA, heuristic canonical names (`dart_*`/`flutter_*`/`package_*`) are replaced automatically
-- recognized call names emit semantic intent comments (stdlib/runtime/native) next to call lines
+- recognized call names emit semantic intent comments (stdlib/runtime/native/package) next to call lines
 - when intent is deterministic, callsites are rewritten to semantic paths and include `was: <original_name>` for traceability
+- canonical `package_<pkg>_<Owner>_<method>` symbols are now rewritten to readable `pkg.Owner.method(...)` callsites with `package:<...>` intent tags
 - selector-backed intent can also rewrite indirect callsites and annotate `indirect via: <target_alias>`
 - when a call argument is exactly `pool[<idx>]` and a string hint is known, it is rendered as `"value" /* pool[<idx>] */`
 - non-exact pool expressions preserve structure and gain inline pool mapping comments (`pool[<idx> /* "value" */]`)


### PR DESCRIPTION
## Summary
- detect canonical package machine symbol names (`package_<pkg>_<Owner>_<method>`) in call intent inference
- rewrite those calls to readable dotted form (`pkg.Owner.method(...)`) with package semantic comments
- add regression test for direct-call rewriting from package machine symbols
- document the behavior in how-it-works/context docs

## Validation
- nix develop -c cargo fmt --all
- nix develop -c cargo test -p flutterdec-decompiler
- nix develop -c cargo clippy -p flutterdec-decompiler --all-targets -- -D warnings
