### PR TITLE
feat(naming): align decompiler generic placeholder filtering

### DIFF
--- a/context.md
+++ b/context.md
@@ -194,6 +194,7 @@ Current scope:
 - pool target symbol synthesis now also emits deterministic `package_<pkg>_<Owner>_<method>` names for `package:*` library targets, improving generic direct-call replacement in app/dependency code paths
 - symbol merge precedence now upgrades heuristic canonical names (`dart_*`, `flutter_*`, `package_*`) to stronger external symbols when both map to the same VA, reducing synthetic call names when symbol maps/ELFs are provided
 - generic symbol detection now also covers common tool-generated placeholders (`FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`) so deterministic semantic/external names can replace them
+- decompiler target-va rewrite now shares the same generic placeholder guard (`sub_*`, `fn_0x*`, `FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`, `fun_<hex>`) so indirect calls do not regress into tool placeholder callnames
 - decompiler call intent now rewrites canonical package-machine symbols (`package_<pkg>_<Owner>_<method>`) into readable `pkg.Owner.method(...)` call paths and emits matching `package:<...>` semantic comments
 - Dart patch-library semantic naming now includes patch module stems when available (for example `dart:core-patch/bool_patch.dart` -> `dart.core_patch.bool_patch.*`) to reduce ambiguous `dart.core_patch.*` callsites
 - selector coverage now includes additional standard families such as `Navigator.pushNamed` and `List.removeAt`, improving deterministic semantic rewrites on real samples

--- a/crates/flutterdec-decompiler/src/control_flow/emit.rs
+++ b/crates/flutterdec-decompiler/src/control_flow/emit.rs
@@ -241,8 +241,7 @@ impl<'a> FuncEmitter<'a> {
     }
 
     fn is_generic_call_name(name: &str) -> bool {
-        let t = name.trim();
-        t.is_empty() || t == "unknown" || t.starts_with("sub_") || t.starts_with("fn_0x")
+        is_generic_symbol_placeholder(name)
     }
 
     fn is_numeric_literal_expr(expr: &str) -> bool {

--- a/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
+++ b/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
@@ -1,6 +1,6 @@
 pub(super) fn infer_call_intent(call_name: &str) -> Option<String> {
     let lower = call_name.to_ascii_lowercase();
-    if lower.starts_with("fn_0x") || lower.starts_with("sub_") {
+    if is_generic_symbol_placeholder(call_name) {
         return None;
     }
 
@@ -62,6 +62,30 @@ pub(super) fn infer_call_intent(call_name: &str) -> Option<String> {
     }
 
     None
+}
+
+pub(super) fn is_generic_symbol_placeholder(name: &str) -> bool {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    let lowered = trimmed.to_ascii_lowercase();
+    if lowered == "unknown"
+        || lowered.starts_with("sub_")
+        || lowered.starts_with("fn_0x")
+        || lowered.starts_with("nullsub_")
+        || lowered.starts_with("loc_")
+        || lowered.starts_with("off_")
+    {
+        return true;
+    }
+    if let Some(rest) = lowered.strip_prefix("fun_") {
+        let token = rest.strip_prefix("0x").unwrap_or(rest).trim_matches('_');
+        if !token.is_empty() && token.chars().all(|c| c.is_ascii_hexdigit()) {
+            return true;
+        }
+    }
+    false
 }
 
 pub(super) fn fallback_call_name_from_selector(selector: &str) -> (String, bool) {
@@ -129,7 +153,7 @@ pub(super) fn readable_call_name_from_intent(
     }
 
     let lower = call_name.to_ascii_lowercase();
-    let generic = lower.starts_with("fn_0x") || lower.starts_with("sub_");
+    let generic = is_generic_symbol_placeholder(call_name);
     let indirect_alias =
         lower == "dispatchtarget" || lower == "cachedtarget" || lower.starts_with("indirecttarget");
     let known_machine_name = lower.starts_with("dart_")

--- a/crates/flutterdec-decompiler/src/tests/cfg_and_stack/call_and_loops.rs
+++ b/crates/flutterdec-decompiler/src/tests/cfg_and_stack/call_and_loops.rs
@@ -1634,6 +1634,74 @@ fn does_not_rewrite_indirect_call_from_target_va_when_symbol_is_generic() {
 }
 
 #[test]
+fn does_not_rewrite_indirect_call_from_target_va_when_symbol_is_tool_placeholder() {
+    let ir = FunctionIr {
+        function_id: 467,
+        name: "indirectMetadataTargetVaToolPlaceholder".to_string(),
+        entry_va: 0xc280,
+        blocks: vec![BasicBlock {
+            id: 0,
+            start_va: 0xc280,
+            instrs: vec![
+                LlirInstr {
+                    va: 0xc280,
+                    op: IROp::LoadPool,
+                    src: "x9".to_string(),
+                    target: "pool[92]".to_string(),
+                },
+                LlirInstr {
+                    va: 0xc284,
+                    op: IROp::Call,
+                    src: "blr x9".to_string(),
+                    target: "x9".to_string(),
+                },
+                LlirInstr {
+                    va: 0xc288,
+                    op: IROp::Return,
+                    src: "ret".to_string(),
+                    target: String::new(),
+                },
+            ],
+            succs: Vec::new(),
+            preds: Vec::new(),
+        }],
+    };
+
+    let mut symbols = HashMap::new();
+    symbols.insert(0x5002u64, "FUN_0012ABCD".to_string());
+    let pool = HashMap::new();
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        92u64,
+        PoolSemanticHint {
+            selector: None,
+            owner_class: None,
+            library_uri: None,
+            target_va: Some(0x5002),
+        },
+    );
+
+    let artifact = emit_pseudocode_with_pool_context(&ir, &symbols, &pool, &metadata);
+    assert!(
+        artifact
+            .source
+            .contains("indirectTarget9(receiver, param1, param2, param3)"),
+        "tool placeholder target symbols should not force semantic rewrite:\n{}",
+        artifact.source
+    );
+    assert!(
+        !artifact.source.contains("FUN_0012ABCD("),
+        "tool placeholder target symbols should not render as callable names:\n{}",
+        artifact.source
+    );
+    assert_eq!(
+        artifact.target_va_symbol_calls, 0,
+        "target_va rewrite counter should remain zero for tool placeholder symbols:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
 fn annotates_pool_mapping_in_indirect_target_comment() {
     let ir = FunctionIr {
         function_id: 47,

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -88,6 +88,7 @@ sequenceDiagram
 - can ingest extra ELF symbol tables and `map-symbols` target JSON to improve direct call naming
 - external descriptive names replace generic placeholders like `sub_*` and `fn_0x*` when addresses match
 - auto-generated disassembler names such as `FUN_<hex>`, `nullsub_*`, `loc_*`, and `off_*` are also treated as generic placeholders during merge
+- indirect `target_va` symbol rewrites apply the same generic-placeholder filter, so tool placeholders are not emitted as callable names
 - pool target metadata now also emits deterministic `package_<pkg>_<Owner>_<method>` symbols for `package:*` libraries (not only `dart:*`/`package:flutter/*`)
 - when stronger external names are available for the same VA, heuristic canonical names (`dart_*`/`flutter_*`/`package_*`) are replaced automatically
 - recognized call names emit semantic intent comments (stdlib/runtime/native/package) next to call lines


### PR DESCRIPTION
## Summary
- add shared decompiler-side generic placeholder detection for symbol names (`sub_*`, `fn_0x*`, `FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`, `fun_<hex>`)
- use the shared filter in call-intent inference and in indirect target-va rewrite gating
- add regression coverage to ensure tool placeholder symbols do not become emitted callable names
- document the new guard behavior in how-it-works/context docs

## Validation
- nix develop -c cargo fmt --all
- nix develop -c cargo test -p flutterdec-decompiler
- nix develop -c cargo clippy -p flutterdec-decompiler --all-targets -- -D warnings
