### PR TITLE
feat(naming): preserve dart patch and owner paths in direct-call intent

### DIFF
--- a/context.md
+++ b/context.md
@@ -197,6 +197,7 @@ Current scope:
 - decompiler target-va rewrite now shares the same generic placeholder guard (`sub_*`, `fn_0x*`, `FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`, `fun_<hex>`) so indirect calls do not regress into tool placeholder callnames
 - decompiler call intent now rewrites canonical package-machine symbols (`package_<pkg>_<Owner>_<method>`) into readable `pkg.Owner.method(...)` call paths and emits matching `package:<...>` semantic comments
 - Dart patch-library semantic naming now includes patch module stems when available (for example `dart:core-patch/bool_patch.dart` -> `dart.core_patch.bool_patch.*`) to reduce ambiguous `dart.core_patch.*` callsites
+- direct-call intent parsing now preserves full Dart library token paths and owner class segments from canonical names (for example `dart_core_patch_bool_patch_fromEnvironment` and `dart_typed_data_TypedData_offsetInBytes`) instead of collapsing to `dart.core.*`
 - selector coverage now includes additional standard families such as `Navigator.pushNamed` and `List.removeAt`, improving deterministic semantic rewrites on real samples
 - selector coverage also includes internal/std selector forms such as `match_end_index` -> `dart.core.Match.end`
 - constructor-like standard selectors are now recognized too (for example `KeyedSubtree`, `StreamIterator`, `Float32x4List`, `Int64List`) and rewritten to semantic `.new` paths

--- a/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
+++ b/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
@@ -4,29 +4,8 @@ pub(super) fn infer_call_intent(call_name: &str) -> Option<String> {
         return None;
     }
 
-    if let Some(rest) = lower.strip_prefix("dart_") {
-        let parts: Vec<&str> = rest.split('_').filter(|p| !p.is_empty()).collect();
-        if let Some(lib) = parts.first() {
-            let known_lib = matches!(
-                *lib,
-                "core"
-                    | "async"
-                    | "collection"
-                    | "convert"
-                    | "io"
-                    | "isolate"
-                    | "math"
-                    | "typed_data"
-                    | "ffi"
-                    | "developer"
-            );
-            if known_lib {
-                if let Some(method) = parts.last() {
-                    return Some(format!("stdlib:dart.{}.{}", lib, method));
-                }
-                return Some(format!("stdlib:dart.{}", lib));
-            }
-        }
+    if let Some(tag) = infer_dart_stdlib_intent(call_name) {
+        return Some(tag);
     }
 
     if let Some(tag) = infer_flutter_framework_intent(call_name) {
@@ -62,6 +41,76 @@ pub(super) fn infer_call_intent(call_name: &str) -> Option<String> {
     }
 
     None
+}
+
+fn infer_dart_stdlib_intent(call_name: &str) -> Option<String> {
+    if !call_name.to_ascii_lowercase().starts_with("dart_") {
+        return None;
+    }
+    let mut parts = call_name.split('_');
+    let head = parts.next().unwrap_or_default();
+    if !head.eq_ignore_ascii_case("dart") {
+        return None;
+    }
+    let tail: Vec<&str> = parts.filter(|p| !p.is_empty()).collect();
+    if tail.len() < 2 {
+        return None;
+    }
+
+    let mut lib_token_end = tail.len() - 1;
+    let mut owner: Option<&str> = None;
+    if tail.len() >= 3 {
+        let owner_candidate = tail[tail.len() - 2];
+        if is_probable_dart_owner_token(owner_candidate) {
+            owner = Some(owner_candidate);
+            lib_token_end = tail.len() - 2;
+        }
+    }
+    if lib_token_end == 0 {
+        return None;
+    }
+
+    let method = tail[tail.len() - 1];
+    if method.is_empty() {
+        return None;
+    }
+    let lib = tail[..lib_token_end]
+        .iter()
+        .map(|v| v.to_ascii_lowercase())
+        .collect::<Vec<_>>()
+        .join("_");
+    let lib_display = render_dart_library_display_segment(&lib);
+    let base_lib = lib.split('_').next().unwrap_or_default();
+    let known_lib = matches!(
+        base_lib,
+        "core" | "async" | "collection" | "convert" | "io" | "isolate" | "math" | "typed"
+            | "ffi" | "developer"
+    );
+    if !known_lib {
+        return None;
+    }
+
+    if let Some(owner) = owner {
+        return Some(format!("stdlib:dart.{}.{}.{}", lib_display, owner, method));
+    }
+    Some(format!("stdlib:dart.{}.{}", lib_display, method))
+}
+
+fn is_probable_dart_owner_token(token: &str) -> bool {
+    token
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_uppercase())
+}
+
+fn render_dart_library_display_segment(lib: &str) -> String {
+    let trimmed = lib.trim().to_ascii_lowercase();
+    if let Some((head, tail)) = trimmed.split_once("_patch_") {
+        if !head.is_empty() && !tail.is_empty() {
+            return format!("{}_patch.{}", head, tail);
+        }
+    }
+    trimmed
 }
 
 pub(super) fn is_generic_symbol_placeholder(name: &str) -> bool {

--- a/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
+++ b/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
@@ -944,6 +944,86 @@ fn annotates_stdlib_call_intent_when_symbol_is_named() {
 }
 
 #[test]
+fn preserves_dart_patch_library_segments_in_call_intent() {
+    let ir = FunctionIr {
+        function_id: 220,
+        name: "dartPatchCall".to_string(),
+        entry_va: 0xf710,
+        blocks: vec![BasicBlock {
+            id: 0,
+            start_va: 0xf710,
+            instrs: vec![
+                LlirInstr {
+                    va: 0xf710,
+                    op: IROp::Call,
+                    src: "bl #0x5100".to_string(),
+                    target: "#0x5100".to_string(),
+                },
+                LlirInstr {
+                    va: 0xf714,
+                    op: IROp::Return,
+                    src: "ret".to_string(),
+                    target: String::new(),
+                },
+            ],
+            succs: Vec::new(),
+            preds: Vec::new(),
+        }],
+    };
+
+    let mut symbols = HashMap::new();
+    symbols.insert(0x5100, "dart_core_patch_bool_patch_fromEnvironment".to_string());
+    let artifact = emit_pseudocode(&ir, &symbols);
+    assert!(
+        artifact.source.contains(
+            "final t1 = dart.core_patch.bool_patch.fromEnvironment(receiver, param1, param2, param3); // stdlib:dart.core_patch.bool_patch.fromEnvironment, was: dart_core_patch_bool_patch_fromEnvironment"
+        ),
+        "dart patch library segment should be preserved in semantic direct-call rewrite:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
+fn preserves_dart_owner_segment_in_call_intent() {
+    let ir = FunctionIr {
+        function_id: 221,
+        name: "dartOwnerCall".to_string(),
+        entry_va: 0xf718,
+        blocks: vec![BasicBlock {
+            id: 0,
+            start_va: 0xf718,
+            instrs: vec![
+                LlirInstr {
+                    va: 0xf718,
+                    op: IROp::Call,
+                    src: "bl #0x5200".to_string(),
+                    target: "#0x5200".to_string(),
+                },
+                LlirInstr {
+                    va: 0xf71c,
+                    op: IROp::Return,
+                    src: "ret".to_string(),
+                    target: String::new(),
+                },
+            ],
+            succs: Vec::new(),
+            preds: Vec::new(),
+        }],
+    };
+
+    let mut symbols = HashMap::new();
+    symbols.insert(0x5200, "dart_typed_data_TypedData_offsetInBytes".to_string());
+    let artifact = emit_pseudocode(&ir, &symbols);
+    assert!(
+        artifact.source.contains(
+            "final t1 = dart.typed_data.TypedData.offsetInBytes(receiver, param1, param2, param3); // stdlib:dart.typed_data.TypedData.offsetInBytes, was: dart_typed_data_TypedData_offsetInBytes"
+        ),
+        "dart owner segment should be preserved in semantic direct-call rewrite:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
 fn annotates_runtime_and_native_call_intents() {
     let ir = FunctionIr {
         function_id: 23,

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -94,6 +94,7 @@ sequenceDiagram
 - recognized call names emit semantic intent comments (stdlib/runtime/native/package) next to call lines
 - when intent is deterministic, callsites are rewritten to semantic paths and include `was: <original_name>` for traceability
 - canonical `package_<pkg>_<Owner>_<method>` symbols are now rewritten to readable `pkg.Owner.method(...)` callsites with `package:<...>` intent tags
+- canonical Dart direct-call symbols preserve patch-library and owner segments in emitted semantic paths (for example `dart.core_patch.bool_patch.fromEnvironment` and `dart.typed_data.TypedData.offsetInBytes`)
 - selector-backed intent can also rewrite indirect callsites and annotate `indirect via: <target_alias>`
 - when a call argument is exactly `pool[<idx>]` and a string hint is known, it is rendered as `"value" /* pool[<idx>] */`
 - non-exact pool expressions preserve structure and gain inline pool mapping comments (`pool[<idx> /* "value" */]`)


### PR DESCRIPTION
## Summary
- improve Dart stdlib machine-symbol intent parsing to preserve full library token paths and optional owner segments
- keep patch-module detail readable in emitted semantic call paths (for example `dart.core_patch.bool_patch.*`)
- add regression tests for patch-library and owner-segment direct-call rewrites
- document the behavior in how-it-works/context docs

## Validation
- nix develop -c cargo fmt --all
- nix develop -c cargo test -p flutterdec-decompiler
- nix develop -c cargo clippy -p flutterdec-decompiler --all-targets -- -D warnings
