### PR TITLE
feat(naming): robustly split package owner and method tokens

### DIFF
--- a/context.md
+++ b/context.md
@@ -196,6 +196,7 @@ Current scope:
 - generic symbol detection now also covers common tool-generated placeholders (`FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`) so deterministic semantic/external names can replace them
 - decompiler target-va rewrite now shares the same generic placeholder guard (`sub_*`, `fn_0x*`, `FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`, `fun_<hex>`) so indirect calls do not regress into tool placeholder callnames
 - decompiler call intent now rewrites canonical package-machine symbols (`package_<pkg>_<Owner>_<method>`) into readable `pkg.Owner.method(...)` call paths and emits matching `package:<...>` semantic comments
+- package-machine intent parsing now preserves underscore-heavy owner/method splits (for example `package_spotube_Foo_Bar_internal_init` -> `spotube.Foo_Bar.internal_init`)
 - Dart patch-library semantic naming now includes patch module stems when available (for example `dart:core-patch/bool_patch.dart` -> `dart.core_patch.bool_patch.*`) to reduce ambiguous `dart.core_patch.*` callsites
 - direct-call intent parsing now preserves full Dart library token paths and owner class segments from canonical names (for example `dart_core_patch_bool_patch_fromEnvironment` and `dart_typed_data_TypedData_offsetInBytes`) instead of collapsing to `dart.core.*`
 - selector coverage now includes additional standard families such as `Navigator.pushNamed` and `List.removeAt`, improving deterministic semantic rewrites on real samples

--- a/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
+++ b/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
@@ -178,8 +178,29 @@ fn infer_package_intent(call_name: &str) -> Option<String> {
         return None;
     }
     let pkg = parts.next()?.trim();
-    let owner = parts.next()?.trim();
-    let method = parts.collect::<Vec<_>>().join("_");
+    let tail: Vec<&str> = parts.filter(|p| !p.is_empty()).collect();
+    if tail.len() < 2 {
+        return None;
+    }
+
+    let owner_end = tail
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(i, token)| {
+            if is_probable_owner_token(token) {
+                Some(i + 1)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(1);
+    if owner_end >= tail.len() {
+        return None;
+    }
+
+    let owner = tail[..owner_end].join("_");
+    let method = tail[owner_end..].join("_");
     if pkg.is_empty() || owner.is_empty() || method.is_empty() {
         return None;
     }
@@ -189,6 +210,13 @@ fn infer_package_intent(call_name: &str) -> Option<String> {
         owner,
         method
     ))
+}
+
+fn is_probable_owner_token(token: &str) -> bool {
+    token
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_uppercase())
 }
 
 pub(super) fn readable_call_name_from_intent(

--- a/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
+++ b/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
@@ -1235,6 +1235,49 @@ fn annotates_package_call_intents_from_machine_symbol_names() {
 }
 
 #[test]
+fn preserves_package_owner_and_method_tokens_with_underscores() {
+    let ir = FunctionIr {
+        function_id: 27,
+        name: "packageUnderscoreCall".to_string(),
+        entry_va: 0xfb08,
+        blocks: vec![BasicBlock {
+            id: 0,
+            start_va: 0xfb08,
+            instrs: vec![
+                LlirInstr {
+                    va: 0xfb08,
+                    op: IROp::Call,
+                    src: "bl #0x6310".to_string(),
+                    target: "#0x6310".to_string(),
+                },
+                LlirInstr {
+                    va: 0xfb0c,
+                    op: IROp::Return,
+                    src: "ret".to_string(),
+                    target: String::new(),
+                },
+            ],
+            succs: Vec::new(),
+            preds: Vec::new(),
+        }],
+    };
+
+    let mut symbols = HashMap::new();
+    symbols.insert(
+        0x6310,
+        "package_spotube_Foo_Bar_internal_init".to_string(),
+    );
+    let artifact = emit_pseudocode(&ir, &symbols);
+    assert!(
+        artifact.source.contains(
+            "spotube.Foo_Bar.internal_init(receiver, param1, param2, param3); // package:spotube.Foo_Bar.internal_init, was: package_spotube_Foo_Bar_internal_init"
+        ),
+        "package intent parsing should preserve underscore-heavy owner/method splits:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
 fn annotates_flutter_scheduler_selector_from_pool_string() {
     let ir = FunctionIr {
         function_id: 26,

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -94,6 +94,7 @@ sequenceDiagram
 - recognized call names emit semantic intent comments (stdlib/runtime/native/package) next to call lines
 - when intent is deterministic, callsites are rewritten to semantic paths and include `was: <original_name>` for traceability
 - canonical `package_<pkg>_<Owner>_<method>` symbols are now rewritten to readable `pkg.Owner.method(...)` callsites with `package:<...>` intent tags
+- package intent parsing now supports underscore-heavy owner/method tokens so generated call paths stay stable on sanitized class/method names
 - canonical Dart direct-call symbols preserve patch-library and owner segments in emitted semantic paths (for example `dart.core_patch.bool_patch.fromEnvironment` and `dart.typed_data.TypedData.offsetInBytes`)
 - selector-backed intent can also rewrite indirect callsites and annotate `indirect via: <target_alias>`
 - when a call argument is exactly `pool[<idx>]` and a string hint is known, it is rendered as `"value" /* pool[<idx>] */`


### PR DESCRIPTION
## Summary
- improve `package_*` machine-symbol parsing by deriving owner/method split from token casing, so underscore-heavy sanitized names remain readable
- preserve stable semantic rewrites for symbols like `package_spotube_Foo_Bar_internal_init`
- add regression test for underscore-heavy owner/method parsing
- update how-it-works/context docs

## Validation
- nix develop -c cargo fmt --all
- nix develop -c cargo test -p flutterdec-decompiler
- nix develop -c cargo clippy -p flutterdec-decompiler --all-targets -- -D warnings
