### PR TITLE
feat(naming): robustly split flutter class and method tokens

### DIFF
--- a/context.md
+++ b/context.md
@@ -197,6 +197,7 @@ Current scope:
 - decompiler target-va rewrite now shares the same generic placeholder guard (`sub_*`, `fn_0x*`, `FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`, `fun_<hex>`) so indirect calls do not regress into tool placeholder callnames
 - decompiler call intent now rewrites canonical package-machine symbols (`package_<pkg>_<Owner>_<method>`) into readable `pkg.Owner.method(...)` call paths and emits matching `package:<...>` semantic comments
 - package-machine intent parsing now preserves underscore-heavy owner/method splits (for example `package_spotube_Foo_Bar_internal_init` -> `spotube.Foo_Bar.internal_init`)
+- framework-machine intent parsing now preserves underscore-heavy class/method splits (for example `flutter_widgets_Render_Flex_perform_layout` -> `flutter.widgets.Render_Flex.perform_layout`)
 - Dart patch-library semantic naming now includes patch module stems when available (for example `dart:core-patch/bool_patch.dart` -> `dart.core_patch.bool_patch.*`) to reduce ambiguous `dart.core_patch.*` callsites
 - direct-call intent parsing now preserves full Dart library token paths and owner class segments from canonical names (for example `dart_core_patch_bool_patch_fromEnvironment` and `dart_typed_data_TypedData_offsetInBytes`) instead of collapsing to `dart.core.*`
 - selector coverage now includes additional standard families such as `Navigator.pushNamed` and `List.removeAt`, improving deterministic semantic rewrites on real samples

--- a/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
+++ b/crates/flutterdec-decompiler/src/helpers/call_intent/intent.rs
@@ -155,8 +155,27 @@ fn infer_flutter_framework_intent(call_name: &str) -> Option<String> {
         return None;
     }
     let lib = parts.next()?;
-    let class = parts.next()?;
-    let method = parts.collect::<Vec<_>>().join("_");
+    let tail: Vec<&str> = parts.filter(|p| !p.is_empty()).collect();
+    if tail.len() < 2 {
+        return None;
+    }
+    let class_end = tail
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(i, token)| {
+            if is_probable_owner_token(token) {
+                Some(i + 1)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(1);
+    if class_end >= tail.len() {
+        return None;
+    }
+    let class = tail[..class_end].join("_");
+    let method = tail[class_end..].join("_");
     if lib.is_empty() || class.is_empty() || method.is_empty() {
         return None;
     }

--- a/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
+++ b/crates/flutterdec-decompiler/src/tests/emit_and_helpers/readability_and_naming.rs
@@ -1132,6 +1132,46 @@ fn annotates_flutter_framework_call_intents() {
 }
 
 #[test]
+fn preserves_flutter_class_and_method_tokens_with_underscores() {
+    let ir = FunctionIr {
+        function_id: 241,
+        name: "frameworkUnderscoreCall".to_string(),
+        entry_va: 0xf910,
+        blocks: vec![BasicBlock {
+            id: 0,
+            start_va: 0xf910,
+            instrs: vec![
+                LlirInstr {
+                    va: 0xf910,
+                    op: IROp::Call,
+                    src: "bl #0x6210".to_string(),
+                    target: "#0x6210".to_string(),
+                },
+                LlirInstr {
+                    va: 0xf914,
+                    op: IROp::Return,
+                    src: "ret".to_string(),
+                    target: String::new(),
+                },
+            ],
+            succs: Vec::new(),
+            preds: Vec::new(),
+        }],
+    };
+
+    let mut symbols = HashMap::new();
+    symbols.insert(0x6210, "flutter_widgets_Render_Flex_perform_layout".to_string());
+    let artifact = emit_pseudocode(&ir, &symbols);
+    assert!(
+        artifact.source.contains(
+            "flutter.widgets.Render_Flex.perform_layout(receiver, param1, param2, param3); // framework:flutter.widgets.Render_Flex.perform_layout, was: flutter_widgets_Render_Flex_perform_layout"
+        ),
+        "flutter intent parsing should preserve underscore-heavy class/method splits:\n{}",
+        artifact.source
+    );
+}
+
+#[test]
 fn annotates_framework_from_pool_selector_when_call_name_is_generic() {
     let ir = FunctionIr {
         function_id: 25,

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -95,6 +95,7 @@ sequenceDiagram
 - when intent is deterministic, callsites are rewritten to semantic paths and include `was: <original_name>` for traceability
 - canonical `package_<pkg>_<Owner>_<method>` symbols are now rewritten to readable `pkg.Owner.method(...)` callsites with `package:<...>` intent tags
 - package intent parsing now supports underscore-heavy owner/method tokens so generated call paths stay stable on sanitized class/method names
+- framework intent parsing now supports underscore-heavy class/method tokens from sanitized machine names
 - canonical Dart direct-call symbols preserve patch-library and owner segments in emitted semantic paths (for example `dart.core_patch.bool_patch.fromEnvironment` and `dart.typed_data.TypedData.offsetInBytes`)
 - selector-backed intent can also rewrite indirect callsites and annotate `indirect via: <target_alias>`
 - when a call argument is exactly `pool[<idx>]` and a string hint is known, it is rendered as `"value" /* pool[<idx>] */`


### PR DESCRIPTION
## Summary
- improve `flutter_*` machine-symbol parsing by deriving class/method split from token casing, keeping underscore-heavy sanitized symbols readable
- preserve stable framework call rewrites for names like `flutter_widgets_Render_Flex_perform_layout`
- add regression test for underscore-heavy framework class/method parsing
- update how-it-works/context docs

## Validation
- nix develop -c cargo fmt --all
- nix develop -c cargo test -p flutterdec-decompiler
- nix develop -c cargo clippy -p flutterdec-decompiler --all-targets -- -D warnings
