### PR TITLE
docs(scope): codify north star, goals, and quality KPIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@
 
 It takes an APK (or `libapp.so`) and emits readable pseudo-Dart plus optional IR/ASM artifacts.
 
+## North Star
+
+Recover readable behavior from Flutter AOT ARM64 binaries with enough semantic structure that reverse engineering decisions can be made from pseudocode and reports.
+
+### Primary Goals
+
+- robust semantic extraction from snapshots and metadata (libraries, classes, functions, selectors, pool semantics)
+- stable reverse-engineering-oriented pseudocode output for Android ARM64 release builds
+- version-aware adapter behavior that can be updated without rewriting core/decompiler logic
+
+### Non-Goals (Current Scope)
+
+- perfect source reconstruction of original Dart code
+- broad multi-arch support in the same maturity level (x86, iOS, JIT modes)
+- dynamic runtime emulation as the default analysis path
+
 ## Who This Is For
 
 - reverse engineers and security researchers

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,6 +64,15 @@ Real-binary regression helpers:
 
 Analysis profile and resolved engine options are written into `report.json` under `analysis`.
 
+Core quality KPIs used to evaluate changes:
+
+- semantic rewrite rates: `semantic_direct_calls`, `semantic_indirect_calls`, and ratios
+- unresolved fallback pressure: selector fallback and dynamic/indirect fallback summaries
+- symbol quality: placeholder replacement progress and generic name prevalence
+- app-focused selection quality in capped runs: selected scope mix and preferred-package ratios
+- metadata coverage: pool value/semantic/target symbol counters
+- reproducibility: stable output under repeated runs for same input/options
+
 ## CI
 
 CI runs on:

--- a/docs/research-decisions.md
+++ b/docs/research-decisions.md
@@ -3,5 +3,30 @@
 - Parser strategy: adapter boundary keeps snapshot version churn isolated.
 - Core language: Rust for stronger typing and safer low-level handling.
 - Adapter language: Python for fast per-hash parser updates.
-- v1 scope: Android ARM64 static-only, correctness prioritized over breadth.
+- Scope baseline: Android ARM64 AOT static-first, correctness prioritized over breadth.
 - Quality gates: strict defaults to prevent low-confidence pseudocode output.
+
+## North Star
+
+Recover readable behavior from Flutter AOT ARM64 binaries with enough semantic structure to support real reverse engineering workflows.
+
+## Primary Goals
+
+- maximize deterministic semantic signal in `ProgramModel` (libraries/classes/functions/object pool metadata)
+- keep decompiler output stable and readable across repeated runs and versions
+- make version upgrades mostly an adapter/backend update problem, not a core rewrite problem
+
+## Non-Goals
+
+- exact recompilable Dart source reconstruction
+- runtime emulation as baseline analysis mode
+- immediate parity for all architectures and snapshot/runtime modes
+
+## Decision Rubric
+
+Use this rubric for architecture and feature decisions:
+
+1. does this increase deterministic semantic recovery for Android ARM64 AOT?
+2. does this improve stability/reproducibility of pseudocode and report outputs?
+3. can this be versioned at adapter/backend boundaries without destabilizing core crates?
+4. is the complexity justified by measurable quality/report improvements?


### PR DESCRIPTION
## Summary
- add explicit project north star and scope framing to README
- document primary goals and non-goals for architecture decisions
- add development KPI rubric used to evaluate semantic quality progress

## Validation
- docs-only change; behavior unchanged
