### PR TITLE
feat(adapter): add schema v3-compatible model metadata

### DIFF
--- a/adapters/python/adapter_template.py
+++ b/adapters/python/adapter_template.py
@@ -107,6 +107,7 @@ def _recover_functions(instr: bytes, base_va: int) -> List[dict]:
                 "entry_va": int(start),
                 "size": int(size),
                 "code_section_va": int(base_va),
+                "name_kind": "placeholder",
             }
         )
     return funcs
@@ -276,6 +277,8 @@ def _pool_entries(strings: List[str]) -> List[dict]:
                 "target_va": None,
                 "owner_class": None,
                 "library_uri": library_uri,
+                "confidence": 0.4,
+                "source": "internal",
             }
         )
     return entries
@@ -452,6 +455,8 @@ def _parse_blutter_pp(pool_path: Path) -> List[dict]:
                 "target_va": target_va,
                 "owner_class": owner_class,
                 "library_uri": library_uri,
+                "confidence": 0.8 if decoded_kind in ("BlutterUnlinkedCall", "BlutterFunctionRef") else 0.6,
+                "source": "blutter",
             }
         )
     return entries
@@ -546,6 +551,7 @@ def _parse_blutter_asm(asm_dir: Path) -> Tuple[List[dict], List[dict], List[dict
                     "entry_va": entry,
                     "size": max(size, 4),
                     "code_section_va": 0,
+                    "name_kind": "placeholder" if name.startswith("sub_") else "heuristic",
                 }
             )
             for decoded_kind, selector, value in _bootflow_candidates_from_name(
@@ -565,6 +571,8 @@ def _parse_blutter_asm(asm_dir: Path) -> Tuple[List[dict], List[dict], List[dict
                         "target_va": int(entry),
                         "owner_class": owner,
                         "library_uri": pending_lib,
+                        "confidence": 0.85,
+                        "source": "synthetic",
                     }
                 )
             pending_name = None
@@ -672,7 +680,7 @@ def _build_blutter_model(
 
     snapshot_hash = _detect_snapshot_hash(vm_data, iso_data, default_snapshot_hash)
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "adapter_kind": "blutter_bridge_model_v1",
         "dart_version": default_version,
         "snapshot_hash": snapshot_hash,
@@ -744,11 +752,12 @@ def entrypoint(default_snapshot_hash: str = "unknown", default_version: str = "u
                 "entry_va": int(args.isolate_instr_va or 0x1000),
                 "size": 128,
                 "code_section_va": int(args.isolate_instr_va or 0x1000),
+                "name_kind": "heuristic",
             }
         ]
 
     payload = {
-        "schema_version": 2,
+        "schema_version": 3,
         "adapter_kind": "dynamic_snapshot_string_model_v1",
         "dart_version": default_version,
         "snapshot_hash": snapshot_hash,

--- a/context.md
+++ b/context.md
@@ -184,6 +184,7 @@ Current scope:
 - declaration typing now also infers `bool` from condition context (`if (x)`, `x && y`, `x == true`) so argument/local declarations keep less `dynamic` noise in control-flow-heavy functions
 - repeated pool-mapped selector literals now hoist into local `String` aliases (for example `poolStr42`) so repeated callsites stay compact and readable
 - adapter object-pool metadata fields (`decoded_kind`, `selector`, `target_va`, `owner_class`, `library_uri`) are now consumed by decompile for deterministic owner-qualified selector rewrites
+- adapter model contract now accepts schema versions `2` and `3`; v3 adds optional per-function `name_kind` and optional object-pool provenance fields (`confidence`, `source`) while preserving v2 compatibility defaults
 - adapter execution now supports backend selection (`auto`, `internal`, `blutter`) so deterministic parser backends can be introduced without changing decompiler core contracts
 - default adapter backend mode is `auto`: it attempts Blutter bridge parsing when configured (`FLUTTERDEC_BLUTTER_CMD` or `FLUTTERDEC_BLUTTER_PY`) and falls back to internal parsing for resilience
 - Blutter bridge parsing currently normalizes `asm/*.dart` and `pp.txt` output into `ProgramModel` (`libraries`, `classes`, `functions`, and best-effort `object_pool` target metadata), synthesizes deterministic `EntryPointCandidate` pool entries for `main`/`runApp`-like functions when present, and serializes blutter invocations with a cache lock to avoid concurrent runner races

--- a/crates/flutterdec-adapter/src/lib.rs
+++ b/crates/flutterdec-adapter/src/lib.rs
@@ -32,6 +32,8 @@ pub struct FunctionInfo {
     pub entry_va: u64,
     pub size: u64,
     pub code_section_va: u64,
+    #[serde(default)]
+    pub name_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +51,10 @@ pub struct ObjectPoolEntry {
     pub owner_class: Option<String>,
     #[serde(default)]
     pub library_uri: Option<String>,
+    #[serde(default)]
+    pub confidence: Option<f64>,
+    #[serde(default)]
+    pub source: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -197,7 +203,7 @@ pub fn resolve_adapter_exec(repo_root: &Path, dart_hash: &str) -> Result<PathBuf
 }
 
 fn validate_model(model: &ProgramModel) -> Result<()> {
-    if model.schema_version != 2 {
+    if model.schema_version != 2 && model.schema_version != 3 {
         bail!(
             "unsupported adapter schema version {}",
             model.schema_version

--- a/crates/flutterdec-core/src/pipeline/runners.rs
+++ b/crates/flutterdec-core/src/pipeline/runners.rs
@@ -683,6 +683,31 @@ pub fn run_decompile(
         HashMap::new()
     };
     let pool_metadata = collect_pool_metadata_stats(&model);
+    let function_name_kind_count = model
+        .functions
+        .iter()
+        .filter(|f| {
+            f.name_kind
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|v| !v.is_empty())
+        })
+        .count();
+    let pool_confidence_count = model
+        .object_pool
+        .iter()
+        .filter(|e| e.confidence.is_some())
+        .count();
+    let pool_source_count = model
+        .object_pool
+        .iter()
+        .filter(|e| {
+            e.source
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|v| !v.is_empty())
+        })
+        .count();
     let pool_semantic_hints = if opt.engine_options.pool_semantic_hints {
         build_pool_semantic_hints(&model, &class_to_library)
     } else {
@@ -1048,6 +1073,13 @@ pub fn run_decompile(
             "engine": &opt.engine_options
         },
         "adapter_kind": model.adapter_kind,
+        "adapter_schema": {
+            "schema_version": model.schema_version,
+            "compatibility_mode": if model.schema_version == 2 { "v2_compat" } else { "native_v3" },
+            "function_name_kind_count": function_name_kind_count,
+            "pool_confidence_count": pool_confidence_count,
+            "pool_source_count": pool_source_count
+        },
         "dart_version": model.dart_version,
         "function_scope": {
             "selected": opt.function_scope.as_str(),

--- a/crates/flutterdec-core/src/pipeline/runners/manifest.rs
+++ b/crates/flutterdec-core/src/pipeline/runners/manifest.rs
@@ -1021,6 +1021,8 @@ fn push_synthetic_hint(
         target_va: Some(hint.target_va),
         owner_class: Some(hint.owner_class.to_string()),
         library_uri: Some(hint.library_uri.to_string()),
+        confidence: None,
+        source: None,
     });
     true
 }

--- a/crates/flutterdec-core/src/pipeline/runners/tests.rs
+++ b/crates/flutterdec-core/src/pipeline/runners/tests.rs
@@ -498,6 +498,7 @@
                     entry_va: 0x1000,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 11,
@@ -506,6 +507,7 @@
                     entry_va: 0x1100,
                     size: 4,
                     code_section_va: 0x1100,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 12,
@@ -514,6 +516,7 @@
                     entry_va: 0x1200,
                     size: 4,
                     code_section_va: 0x1200,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 13,
@@ -522,6 +525,7 @@
                     entry_va: 0x1300,
                     size: 4,
                     code_section_va: 0x1300,
+                name_kind: None,
                 },
             ],
             object_pool: Vec::new(),
@@ -562,6 +566,7 @@
                     entry_va: 0x1200,
                     size: 4,
                     code_section_va: 0x1200,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 13,
@@ -570,6 +575,7 @@
                     entry_va: 0x1300,
                     size: 4,
                     code_section_va: 0x1300,
+                name_kind: None,
                 },
             ],
             object_pool: Vec::new(),
@@ -620,6 +626,7 @@
                     entry_va: 0x1200,
                     size: 4,
                     code_section_va: 0x1200,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 13,
@@ -628,6 +635,7 @@
                     entry_va: 0x1300,
                     size: 4,
                     code_section_va: 0x1300,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 14,
@@ -636,6 +644,7 @@
                     entry_va: 0x1400,
                     size: 4,
                     code_section_va: 0x1400,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 15,
@@ -644,6 +653,7 @@
                     entry_va: 0x1500,
                     size: 4,
                     code_section_va: 0x1500,
+                name_kind: None,
                 },
             ],
             object_pool: Vec::new(),
@@ -697,6 +707,7 @@
                     entry_va: 0x1000,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 11,
@@ -705,6 +716,7 @@
                     entry_va: 0x1100,
                     size: 4,
                     code_section_va: 0x1100,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 12,
@@ -713,6 +725,7 @@
                     entry_va: 0x1200,
                     size: 4,
                     code_section_va: 0x1200,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 13,
@@ -721,6 +734,7 @@
                     entry_va: 0x1300,
                     size: 4,
                     code_section_va: 0x1300,
+                name_kind: None,
                 },
             ],
             object_pool: Vec::new(),
@@ -777,6 +791,7 @@
             entry_va: 0x1000,
             size: 4,
             code_section_va: 0x1000,
+        name_kind: None,
         };
         assert_eq!(
             canonical_standard_model_name(&dart_fn, &class_lib).as_deref(),
@@ -790,6 +805,7 @@
             entry_va: 0x1800,
             size: 4,
             code_section_va: 0x1800,
+        name_kind: None,
         };
         assert_eq!(
             canonical_standard_model_name(&dart_patch_fn, &class_lib).as_deref(),
@@ -803,6 +819,7 @@
             entry_va: 0x2000,
             size: 4,
             code_section_va: 0x2000,
+        name_kind: None,
         };
         assert_eq!(
             canonical_standard_model_name(&flutter_fn, &class_lib).as_deref(),
@@ -816,6 +833,7 @@
             entry_va: 0x3000,
             size: 4,
             code_section_va: 0x3000,
+        name_kind: None,
         };
         assert_eq!(
             canonical_standard_model_name(&render_fn, &class_lib).as_deref(),
@@ -829,6 +847,7 @@
             entry_va: 0x4000,
             size: 4,
             code_section_va: 0x4000,
+        name_kind: None,
         };
         assert!(canonical_standard_model_name(&generic_fn, &class_lib).is_none());
     }
@@ -1000,6 +1019,8 @@
                     target_va: Some(0x1000),
                     owner_class: Some("Global".to_string()),
                     library_uri: Some("package:app/main.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 2,
@@ -1010,6 +1031,8 @@
                     target_va: Some(0x1010),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 3,
@@ -1020,6 +1043,8 @@
                     target_va: Some(0x1020),
                     owner_class: Some("MainActivityHost".to_string()),
                     library_uri: Some("package:app/main.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 4,
@@ -1030,6 +1055,8 @@
                     target_va: Some(0x1030),
                     owner_class: Some("Global".to_string()),
                     library_uri: Some("package:app/main.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1078,6 +1105,8 @@
                     target_va: Some(0x2000),
                     owner_class: Some("Global".to_string()),
                     library_uri: Some("package:app/main.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 2,
@@ -1088,6 +1117,8 @@
                     target_va: Some(0x2000),
                     owner_class: Some("Global".to_string()),
                     library_uri: Some("package:app/main.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1139,6 +1170,7 @@
                     entry_va: 0x1000,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 2,
@@ -1147,6 +1179,7 @@
                     entry_va: 0x1004,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 3,
@@ -1155,6 +1188,7 @@
                     entry_va: 0x1008,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 4,
@@ -1163,6 +1197,7 @@
                     entry_va: 0x100c,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
                 flutterdec_adapter::FunctionInfo {
                     id: 5,
@@ -1171,6 +1206,7 @@
                     entry_va: 0x1010,
                     size: 4,
                     code_section_va: 0x1000,
+                name_kind: None,
                 },
             ],
             object_pool: Vec::new(),
@@ -1248,6 +1284,8 @@
                     target_va: Some(0x1234),
                     owner_class: Some("WidgetsBindingObserver".to_string()),
                     library_uri: Some("package:flutter/src/widgets/binding.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 8,
@@ -1258,6 +1296,8 @@
                     target_va: None,
                     owner_class: None,
                     library_uri: None,
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1296,6 +1336,8 @@
                     target_va: Some(0x1000),
                     owner_class: Some("State".to_string()),
                     library_uri: Some("package:flutter/src/widgets/framework.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 2,
@@ -1306,6 +1348,8 @@
                     target_va: None,
                     owner_class: None,
                     library_uri: None,
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1339,6 +1383,8 @@
                     target_va: Some(0x1234),
                     owner_class: Some("WidgetsBindingObserver".to_string()),
                     library_uri: Some("package:flutter/src/widgets/binding.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 8,
@@ -1349,6 +1395,8 @@
                     target_va: Some(0x2234),
                     owner_class: Some("Int64List".to_string()),
                     library_uri: Some("dart:typed_data".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 flutterdec_adapter::ObjectPoolEntry {
                     index: 9,
@@ -1359,6 +1407,8 @@
                     target_va: Some(0x3234),
                     owner_class: Some("ConnectService".to_string()),
                     library_uri: Some("package:spotube/models/connect/load.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1403,6 +1453,7 @@
                 entry_va: 0x4000,
                 size: 4,
                 code_section_va: 0x4000,
+            name_kind: None,
             }],
             object_pool: vec![flutterdec_adapter::ObjectPoolEntry {
                 index: 21,
@@ -1413,6 +1464,8 @@
                 target_va: Some(0x4000),
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
 

--- a/crates/flutterdec-disasm-arm64/src/lib.rs
+++ b/crates/flutterdec-disasm-arm64/src/lib.rs
@@ -1346,6 +1346,7 @@ mod tests {
                 entry_va: 0x1000,
                 size: 8,
                 code_section_va: 0x1000,
+                name_kind: None,
             }],
             object_pool: vec![ObjectPoolEntry {
                 index: 0,
@@ -1356,6 +1357,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1406,6 +1409,7 @@ mod tests {
                     entry_va: 0x1000,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1414,6 +1418,7 @@ mod tests {
                     entry_va: 0x1004,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1425,6 +1430,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1475,6 +1482,7 @@ mod tests {
                     entry_va: 0x2000,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1483,6 +1491,7 @@ mod tests {
                     entry_va: 0x2004,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1494,6 +1503,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1529,6 +1540,7 @@ mod tests {
                     entry_va: 0x3000,
                     size: 4,
                     code_section_va: 0x3000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1537,6 +1549,7 @@ mod tests {
                     entry_va: 0x3004,
                     size: 4,
                     code_section_va: 0x3000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1548,6 +1561,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1583,6 +1598,7 @@ mod tests {
                     entry_va: 0x4000,
                     size: 4,
                     code_section_va: 0x4000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1591,6 +1607,7 @@ mod tests {
                     entry_va: 0x4004,
                     size: 4,
                     code_section_va: 0x4000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![
@@ -1603,6 +1620,8 @@ mod tests {
                     target_va: Some(0x4004),
                     owner_class: Some("MainActivity".to_string()),
                     library_uri: Some("package:app/main.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 ObjectPoolEntry {
                     index: 1,
@@ -1613,6 +1632,8 @@ mod tests {
                     target_va: None,
                     owner_class: None,
                     library_uri: None,
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1649,6 +1670,7 @@ mod tests {
                     entry_va: 0x5000,
                     size: 4,
                     code_section_va: 0x5000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1657,6 +1679,7 @@ mod tests {
                     entry_va: 0x5004,
                     size: 4,
                     code_section_va: 0x5000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1668,6 +1691,8 @@ mod tests {
                 target_va: Some(0x5004),
                 owner_class: Some("Global".to_string()),
                 library_uri: Some("package:app/main.dart".to_string()),
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1703,6 +1728,7 @@ mod tests {
                     entry_va: 0x50a0,
                     size: 4,
                     code_section_va: 0x50a0,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1711,6 +1737,7 @@ mod tests {
                     entry_va: 0x50a4,
                     size: 4,
                     code_section_va: 0x50a0,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1722,6 +1749,8 @@ mod tests {
                 target_va: Some(0x50a4),
                 owner_class: Some("Global".to_string()),
                 library_uri: Some("package:app/main.dart".to_string()),
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1757,6 +1786,7 @@ mod tests {
                     entry_va: 0x50aa,
                     size: 4,
                     code_section_va: 0x50aa,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1765,6 +1795,7 @@ mod tests {
                     entry_va: 0x50ae,
                     size: 4,
                     code_section_va: 0x50aa,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1776,6 +1807,8 @@ mod tests {
                 target_va: Some(0x50ae),
                 owner_class: Some("Global".to_string()),
                 library_uri: Some("package:app/main.dart".to_string()),
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1811,6 +1844,7 @@ mod tests {
                     entry_va: 0x50b0,
                     size: 4,
                     code_section_va: 0x50b0,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1819,6 +1853,7 @@ mod tests {
                     entry_va: 0x50b4,
                     size: 4,
                     code_section_va: 0x50b0,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -1830,6 +1865,8 @@ mod tests {
                 target_va: Some(0x50b4),
                 owner_class: Some("RouterHost".to_string()),
                 library_uri: Some("package:app/router.dart".to_string()),
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -1880,6 +1917,7 @@ mod tests {
                     entry_va: 0x50c0,
                     size: 4,
                     code_section_va: 0x50c0,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1888,6 +1926,7 @@ mod tests {
                     entry_va: 0x50c4,
                     size: 4,
                     code_section_va: 0x50c0,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![
@@ -1900,6 +1939,8 @@ mod tests {
                     target_va: Some(0x50c0),
                     owner_class: Some("AppRouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 ObjectPoolEntry {
                     index: 1,
@@ -1910,6 +1951,8 @@ mod tests {
                     target_va: Some(0x50c4),
                     owner_class: Some("WidgetsBindingObserver".to_string()),
                     library_uri: Some("package:flutter/src/widgets/app.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -1946,6 +1989,7 @@ mod tests {
                     entry_va: 0x5200,
                     size: 4,
                     code_section_va: 0x5200,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -1954,6 +1998,7 @@ mod tests {
                     entry_va: 0x5204,
                     size: 4,
                     code_section_va: 0x5200,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -1962,6 +2007,7 @@ mod tests {
                     entry_va: 0x5208,
                     size: 4,
                     code_section_va: 0x5200,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![
@@ -1974,6 +2020,8 @@ mod tests {
                     target_va: Some(0x5200),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 ObjectPoolEntry {
                     index: 1,
@@ -1984,6 +2032,8 @@ mod tests {
                     target_va: Some(0x5204),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 ObjectPoolEntry {
                     index: 2,
@@ -1994,6 +2044,8 @@ mod tests {
                     target_va: Some(0x5208),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -2040,6 +2092,7 @@ mod tests {
                     entry_va: 0x5300,
                     size: 4,
                     code_section_va: 0x5300,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2048,6 +2101,7 @@ mod tests {
                     entry_va: 0x5304,
                     size: 4,
                     code_section_va: 0x5300,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -2056,6 +2110,7 @@ mod tests {
                     entry_va: 0x5308,
                     size: 4,
                     code_section_va: 0x5300,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![
@@ -2068,6 +2123,8 @@ mod tests {
                     target_va: Some(0x5300),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 ObjectPoolEntry {
                     index: 1,
@@ -2078,6 +2135,8 @@ mod tests {
                     target_va: Some(0x5304),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
                 ObjectPoolEntry {
                     index: 2,
@@ -2088,6 +2147,8 @@ mod tests {
                     target_va: Some(0x5308),
                     owner_class: Some("RouterHost".to_string()),
                     library_uri: Some("package:app/router.dart".to_string()),
+                    confidence: None,
+                    source: None,
                 },
             ],
         };
@@ -2140,6 +2201,7 @@ mod tests {
                     entry_va: 0x5100,
                     size: 4,
                     code_section_va: 0x5100,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2148,6 +2210,7 @@ mod tests {
                     entry_va: 0x5104,
                     size: 4,
                     code_section_va: 0x5100,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2159,6 +2222,8 @@ mod tests {
                 target_va: Some(0x5104),
                 owner_class: Some("MyApp".to_string()),
                 library_uri: Some("package:spotube/main.dart".to_string()),
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![0xc0, 0x03, 0x5f, 0xd6, 0xc0, 0x03, 0x5f, 0xd6];
@@ -2209,6 +2274,7 @@ mod tests {
                     entry_va: 0x2000,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2217,6 +2283,7 @@ mod tests {
                     entry_va: 0x2004,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -2225,6 +2292,7 @@ mod tests {
                     entry_va: 0x2008,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 3,
@@ -2233,6 +2301,7 @@ mod tests {
                     entry_va: 0x200c,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 4,
@@ -2241,6 +2310,7 @@ mod tests {
                     entry_va: 0x2010,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 5,
@@ -2249,6 +2319,7 @@ mod tests {
                     entry_va: 0x2014,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 6,
@@ -2257,6 +2328,7 @@ mod tests {
                     entry_va: 0x2018,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 7,
@@ -2265,6 +2337,7 @@ mod tests {
                     entry_va: 0x201c,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 8,
@@ -2273,6 +2346,7 @@ mod tests {
                     entry_va: 0x2020,
                     size: 4,
                     code_section_va: 0x2000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2284,6 +2358,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = [0xc0u8, 0x03, 0x5f, 0xd6].repeat(9);
@@ -2319,6 +2395,7 @@ mod tests {
                     entry_va: 0x1000,
                     size: 8,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2327,6 +2404,7 @@ mod tests {
                     entry_va: 0x1010,
                     size: 0x100,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2338,6 +2416,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = [0xc0u8, 0x03, 0x5f, 0xd6].repeat(68);
@@ -2373,6 +2453,7 @@ mod tests {
                     entry_va: 0x1000,
                     size: 12,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2381,6 +2462,7 @@ mod tests {
                     entry_va: 0x1010,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -2389,6 +2471,7 @@ mod tests {
                     entry_va: 0x1020,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2400,6 +2483,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![
@@ -2445,6 +2530,7 @@ mod tests {
                     entry_va: 0x1000,
                     size: 32,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2453,6 +2539,7 @@ mod tests {
                     entry_va: 0x1020,
                     size: 32,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -2461,6 +2548,7 @@ mod tests {
                     entry_va: 0x1040,
                     size: 32,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 3,
@@ -2469,6 +2557,7 @@ mod tests {
                     entry_va: 0x1060,
                     size: 32,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2480,6 +2569,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = [0xc0u8, 0x03, 0x5f, 0xd6].repeat(40);
@@ -2497,6 +2588,7 @@ mod tests {
             entry_va: 0x6000,
             size: 32,
             code_section_va: 0x6000,
+            name_kind: None,
         };
         let noisy = FunctionInfo {
             id: 1,
@@ -2505,6 +2597,7 @@ mod tests {
             entry_va: 0x6010,
             size: 32,
             code_section_va: 0x6000,
+            name_kind: None,
         };
 
         let mut owner_library = HashMap::new();
@@ -2566,6 +2659,7 @@ mod tests {
             entry_va: 0x6100,
             size: 32,
             code_section_va: 0x6100,
+            name_kind: None,
         };
         let core_func = FunctionInfo {
             id: 1,
@@ -2574,6 +2668,7 @@ mod tests {
             entry_va: 0x6110,
             size: 32,
             code_section_va: 0x6100,
+            name_kind: None,
         };
 
         let mut owner_library = HashMap::new();
@@ -2638,6 +2733,7 @@ mod tests {
             entry_va: 0x7100,
             size: 64,
             code_section_va: 0x7000,
+            name_kind: None,
         };
         let dep_func = FunctionInfo {
             id: 1,
@@ -2646,6 +2742,7 @@ mod tests {
             entry_va: 0x7200,
             size: 64,
             code_section_va: 0x7000,
+            name_kind: None,
         };
         let mut owner_library = HashMap::new();
         owner_library.insert(
@@ -2711,6 +2808,7 @@ mod tests {
                 entry_va: 0x8000 + (i * 4),
                 size: 32,
                 code_section_va: 0x8000,
+                name_kind: None,
             });
         }
         for i in 0..3u64 {
@@ -2721,6 +2819,7 @@ mod tests {
                 entry_va: 0x9000 + (i * 4),
                 size: 32,
                 code_section_va: 0x8000,
+                name_kind: None,
             });
         }
 
@@ -2782,6 +2881,7 @@ mod tests {
                     entry_va: 0x1000,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2790,6 +2890,7 @@ mod tests {
                     entry_va: 0x1004,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -2798,6 +2899,7 @@ mod tests {
                     entry_va: 0x1008,
                     size: 4,
                     code_section_va: 0x1000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2809,6 +2911,8 @@ mod tests {
                 target_va: Some(0x1000),
                 owner_class: Some("Global".to_string()),
                 library_uri: Some("package:app/main.dart".to_string()),
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = vec![
@@ -2849,6 +2953,7 @@ mod tests {
                     entry_va: 0x7000,
                     size: 4,
                     code_section_va: 0x7000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2857,6 +2962,7 @@ mod tests {
                     entry_va: 0x7004,
                     size: 4,
                     code_section_va: 0x7000,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 2,
@@ -2865,6 +2971,7 @@ mod tests {
                     entry_va: 0x7008,
                     size: 4,
                     code_section_va: 0x7000,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2876,6 +2983,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = [0xc0u8, 0x03, 0x5f, 0xd6].repeat(3);
@@ -2912,6 +3021,7 @@ mod tests {
                     entry_va: 0x7100,
                     size: 4,
                     code_section_va: 0x7100,
+                    name_kind: None,
                 },
                 FunctionInfo {
                     id: 1,
@@ -2920,6 +3030,7 @@ mod tests {
                     entry_va: 0x7104,
                     size: 4,
                     code_section_va: 0x7100,
+                    name_kind: None,
                 },
             ],
             object_pool: vec![ObjectPoolEntry {
@@ -2931,6 +3042,8 @@ mod tests {
                 target_va: None,
                 owner_class: None,
                 library_uri: None,
+                confidence: None,
+                source: None,
             }],
         };
         let bytes = [0xc0u8, 0x03, 0x5f, 0xd6].repeat(2);

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -248,19 +248,24 @@ Produced by adapter. Main fields:
 - `functions[]`
 - `object_pool[]`
 
+Schema compatibility:
+
+- v2 and v3 are accepted by core
+- v3 adds richer semantic metadata while preserving v2 compatibility defaults
+
 Minimal example:
 
 ```json
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "adapter_kind": "dynamic_snapshot_string_model_v1",
   "dart_version": "unknown",
   "snapshot_hash": "63f9...abcd",
   "arch": "arm64",
   "libraries": [{"id": 0, "uri": "package:app/main.dart", "name_display": "package:app/main.dart"}],
   "classes": [{"id": 0, "name": "Global", "super": "Object", "lib": "package:app/main.dart"}],
-  "functions": [{"id": 0, "name": "sub_656c1c", "owner_class": "Global", "entry_va": 6640668, "size": 320, "code_section_va": 6635520}],
-  "object_pool": [{"index": 0, "kind": "String", "value": "package:app/main.dart"}]
+  "functions": [{"id": 0, "name": "sub_656c1c", "owner_class": "Global", "entry_va": 6640668, "size": 320, "code_section_va": 6635520, "name_kind": "placeholder"}],
+  "object_pool": [{"index": 0, "kind": "String", "value": "package:app/main.dart", "decoded_kind": "LibraryUri", "library_uri": "package:app/main.dart", "confidence": 0.4, "source": "internal"}]
 }
 ```
 

--- a/schemas/adapter.schema.json
+++ b/schemas/adapter.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "flutterdec adapter output schema",
   "type": "object",
+  "additionalProperties": true,
   "required": [
     "schema_version",
     "adapter_kind",
@@ -14,14 +15,80 @@
     "object_pool"
   ],
   "properties": {
-    "schema_version": { "type": "integer", "const": 2 },
+    "schema_version": { "type": "integer", "enum": [2, 3] },
     "adapter_kind": { "type": "string" },
     "dart_version": { "type": "string" },
     "snapshot_hash": { "type": "string" },
     "arch": { "type": "string" },
-    "libraries": { "type": "array" },
-    "classes": { "type": "array" },
-    "functions": { "type": "array" },
-    "object_pool": { "type": "array" }
+    "libraries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "uri", "name_display"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "integer", "minimum": 0 },
+          "uri": { "type": "string" },
+          "name_display": { "type": "string" }
+        }
+      }
+    },
+    "classes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "super", "lib"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "integer", "minimum": 0 },
+          "name": { "type": "string" },
+          "super": { "type": "string" },
+          "lib": { "type": "string" }
+        }
+      }
+    },
+    "functions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "name", "owner_class", "entry_va", "size", "code_section_va"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "integer", "minimum": 0 },
+          "name": { "type": "string" },
+          "owner_class": { "type": "string" },
+          "entry_va": { "type": "integer", "minimum": 0 },
+          "size": { "type": "integer", "minimum": 0 },
+          "code_section_va": { "type": "integer", "minimum": 0 },
+          "name_kind": {
+            "type": "string",
+            "enum": ["exact", "external", "heuristic", "placeholder"]
+          }
+        }
+      }
+    },
+    "object_pool": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["index", "kind", "value"],
+        "additionalProperties": true,
+        "properties": {
+          "index": { "type": "integer", "minimum": 0 },
+          "kind": { "type": "string" },
+          "value": { "type": "string" },
+          "decoded_kind": { "type": "string" },
+          "selector": { "type": "string" },
+          "target_va": { "type": "integer", "minimum": 0 },
+          "owner_class": { "type": "string" },
+          "library_uri": { "type": "string" },
+          "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+          "source": {
+            "type": "string",
+            "enum": ["vm", "blutter", "internal", "synthetic", "unknown"]
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- extend adapter model compatibility to accept schema versions 2 and 3
- define richer adapter schema metadata for function naming and object-pool provenance (`name_kind`, `confidence`, `source`)
- emit schema v3 from Python adapter backends while preserving v2-compatible optional semantics in Rust loaders
- add report diagnostics for adapter schema mode and metadata coverage counters
- update docs/context for v2/v3 compatibility and v3 metadata fields

## Validation
- nix develop -c cargo fmt --all
- nix develop -c cargo test --workspace
- nix develop -c cargo clippy --workspace --all-targets -- -D warnings
