### PR TITLE
feat(diff): add recovered-function build diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ flutterdec decompile ./sample.apk -o ./out \
   --extra-symbol-elf ./libflutter.unstripped.so
 ```
 
+5. Optional: compare two builds by recovered function signatures:
+
+```bash
+flutterdec diff --old ./old.apk --new ./new.apk -o ./out-diff --json
+```
+
 ## Analysis Profiles
 
 `decompile` exposes analysis-engine profiles so you can trade detail for speed.
@@ -194,6 +200,7 @@ Main outputs under `-o <OUT_DIR>`:
 - `pseudocode/*.dartpseudo`
 - `quality.json`
 - `report.json`
+- `diff_report.json` (if `flutterdec diff`)
 - `asm/*.s` (if `--emit-asm`)
 - opcode-prefixed asm lines (if `--emit-asm --emit-asm-opcodes`)
 - `ghidra_apply_symbols.py` (if `--emit-ghidra-script`; applies symbol names and pool-load comments)

--- a/context.md
+++ b/context.md
@@ -197,6 +197,7 @@ Current scope:
 - symbol merge now uses an explicit quality lattice (`placeholder` < `heuristic` < `external` < `exact`) and reports final name-quality mix plus merge replacement diagnostics under `name_resolution` in `report.json`
 - adapter schema reporting now includes `function_name_kind_breakdown` (`exact`, `external`, `heuristic`, `placeholder`, `unknown`, `unspecified`) so model naming confidence can be tracked across versions/backends
 - decompile reports now also include `adapter_selection` tracing (requested backend, resolved backend, adapter executable and manifest mapping, snapshot hash agreement) plus best-effort `engine_fingerprint_context` from nearby or APK-bundled `libflutter.so`
+- CLI now includes `flutterdec diff --old ... --new ...` to compare two builds at the recovered-function descriptor level (added/removed/common counts plus top changed signatures), with the same scope/package filters used by decompile
 - generic symbol detection now also covers common tool-generated placeholders (`FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`) so deterministic semantic/external names can replace them
 - decompiler target-va rewrite now shares the same generic placeholder guard (`sub_*`, `fn_0x*`, `FUN_<hex>`, `nullsub_*`, `loc_*`, `off_*`, `fun_<hex>`) so indirect calls do not regress into tool placeholder callnames
 - decompiler call intent now rewrites canonical package-machine symbols (`package_<pkg>_<Owner>_<method>`) into readable `pkg.Owner.method(...)` call paths and emits matching `package:<...>` semantic comments

--- a/crates/flutterdec-cli/src/main.rs
+++ b/crates/flutterdec-cli/src/main.rs
@@ -2,9 +2,9 @@ use anyhow::{bail, Context, Result};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use flutterdec_adapter::install_adapter;
 use flutterdec_core::{
-    available_adapters, run_decompile, run_engine_fingerprint, run_info, run_symbol_map,
+    available_adapters, run_decompile, run_diff, run_engine_fingerprint, run_info, run_symbol_map,
     AdapterBackend, DecompileAnalysisProfile, DecompileEngineOptionOverrides,
-    DecompileEngineOptions, DecompileOptions, EngineFingerprintOptions, FunctionScope,
+    DecompileEngineOptions, DecompileOptions, DiffOptions, EngineFingerprintOptions, FunctionScope,
     SymbolMapOptions,
 };
 use std::path::{Path, PathBuf};
@@ -21,6 +21,7 @@ struct Cli {
 enum Command {
     Info(InfoCmd),
     Decompile(DecompileCmd),
+    Diff(DiffCmd),
     EngineFingerprint(EngineFingerprintCmd),
     MapSymbols(MapSymbolsCmd),
     Adapter(AdapterCmd),
@@ -92,6 +93,24 @@ struct DecompileCmd {
     with_bootflow_category_seeds: bool,
     #[arg(long)]
     no_bootflow_category_seeds: bool,
+}
+
+#[derive(Args, Debug)]
+struct DiffCmd {
+    #[arg(long = "old")]
+    old_input: PathBuf,
+    #[arg(long = "new")]
+    new_input: PathBuf,
+    #[arg(short = 'o', long = "out")]
+    out_dir: PathBuf,
+    #[arg(long, value_enum, default_value_t = FunctionScopeArg::AppUnknown)]
+    function_scope: FunctionScopeArg,
+    #[arg(long = "app-package")]
+    app_packages: Vec<String>,
+    #[arg(long, value_enum, default_value_t = AdapterBackendArg::Auto)]
+    adapter_backend: AdapterBackendArg,
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -215,6 +234,7 @@ fn main() -> Result<()> {
     match cli.command {
         Command::Info(cmd) => handle_info(&repo_root, cmd)?,
         Command::Decompile(cmd) => handle_decompile(&repo_root, cmd)?,
+        Command::Diff(cmd) => handle_diff(&repo_root, cmd)?,
         Command::EngineFingerprint(cmd) => handle_engine_fingerprint(cmd)?,
         Command::MapSymbols(cmd) => handle_map_symbols(cmd)?,
         Command::Adapter(cmd) => handle_adapter(&repo_root, cmd)?,
@@ -253,6 +273,43 @@ fn handle_decompile(repo_root: &Path, cmd: DecompileCmd) -> Result<()> {
     let opt = build_decompile_options(cmd)?;
     let quality = run_decompile(repo_root, &input, &opt)?;
     println!("{}", serde_json::to_string_pretty(&quality)?);
+    Ok(())
+}
+
+fn handle_diff(repo_root: &Path, cmd: DiffCmd) -> Result<()> {
+    let old_input = cmd.old_input.clone();
+    let new_input = cmd.new_input.clone();
+    let json = cmd.json;
+    let opt = DiffOptions {
+        out_dir: cmd.out_dir,
+        adapter_backend: cmd.adapter_backend.to_core(),
+        function_scope: cmd.function_scope.to_core(),
+        app_packages: cmd.app_packages,
+    };
+    let report = run_diff(repo_root, &old_input, &new_input, &opt)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("old input: {}", report.old_input_path);
+        println!("new input: {}", report.new_input_path);
+        println!(
+            "snapshot hash: old={} new={}",
+            report.old_snapshot_hash, report.new_snapshot_hash
+        );
+        println!(
+            "dart version: old={} new={}",
+            report.old_dart_version, report.new_dart_version
+        );
+        println!(
+            "functions: old={} new={} common={} added={} removed={}",
+            report.old_function_count,
+            report.new_function_count,
+            report.common_function_count,
+            report.added_function_count,
+            report.removed_function_count
+        );
+        println!("report: {}", report.report_path);
+    }
     Ok(())
 }
 
@@ -563,5 +620,53 @@ mod tests {
             panic!("expected decompile command");
         };
         assert!(matches!(cmd.adapter_backend, AdapterBackendArg::Blutter));
+    }
+
+    #[test]
+    fn diff_scope_defaults_to_app_unknown() {
+        let cli = Cli::try_parse_from([
+            "flutterdec",
+            "diff",
+            "--old",
+            "old.apk",
+            "--new",
+            "new.apk",
+            "-o",
+            "out",
+        ])
+        .expect("parse");
+        let Command::Diff(cmd) = cli.command else {
+            panic!("expected diff command");
+        };
+        assert!(matches!(cmd.function_scope, FunctionScopeArg::AppUnknown));
+    }
+
+    #[test]
+    fn diff_accepts_backend_and_package_filters() {
+        let cli = Cli::try_parse_from([
+            "flutterdec",
+            "diff",
+            "--old",
+            "old.apk",
+            "--new",
+            "new.apk",
+            "-o",
+            "out",
+            "--adapter-backend",
+            "blutter",
+            "--app-package",
+            "spotube",
+            "--app-package",
+            "provider",
+            "--function-scope",
+            "all",
+        ])
+        .expect("parse");
+        let Command::Diff(cmd) = cli.command else {
+            panic!("expected diff command");
+        };
+        assert!(matches!(cmd.adapter_backend, AdapterBackendArg::Blutter));
+        assert!(matches!(cmd.function_scope, FunctionScopeArg::All));
+        assert_eq!(cmd.app_packages, vec!["spotube", "provider"]);
     }
 }

--- a/crates/flutterdec-core/src/lib.rs
+++ b/crates/flutterdec-core/src/lib.rs
@@ -40,6 +40,14 @@ pub struct DecompileOptions {
     pub engine_options: DecompileEngineOptions,
 }
 
+#[derive(Debug, Clone)]
+pub struct DiffOptions {
+    pub out_dir: PathBuf,
+    pub adapter_backend: AdapterBackend,
+    pub function_scope: FunctionScope,
+    pub app_packages: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum FunctionScope {
     AppUnknown,
@@ -191,6 +199,26 @@ pub struct QualityReport {
     pub placeholder_cond_markers: usize,
     pub omitted_path_markers: usize,
     pub loop_backedge_markers: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffReport {
+    pub old_input_path: String,
+    pub new_input_path: String,
+    pub old_snapshot_hash: String,
+    pub new_snapshot_hash: String,
+    pub old_dart_version: String,
+    pub new_dart_version: String,
+    pub function_scope: String,
+    pub app_packages: Vec<String>,
+    pub old_function_count: usize,
+    pub new_function_count: usize,
+    pub common_function_count: usize,
+    pub added_function_count: usize,
+    pub removed_function_count: usize,
+    pub added_functions_top: Vec<String>,
+    pub removed_functions_top: Vec<String>,
+    pub report_path: String,
 }
 
 include!("pipeline/helpers.rs");

--- a/crates/flutterdec-core/src/pipeline/runners.rs
+++ b/crates/flutterdec-core/src/pipeline/runners.rs
@@ -22,7 +22,7 @@ use runners_symbols::{
 };
 #[cfg(test)]
 use runners_symbols::{is_generic_symbol_name, normalize_external_symbol_name};
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write as FmtWrite;
 use std::io::Read;
 use tempfile::NamedTempFile;
@@ -970,6 +970,88 @@ pub fn run_info(repo_root: &Path, input_path: &Path) -> Result<InfoOutput> {
     }
 
     Ok(out)
+}
+
+fn function_descriptor(
+    func: &flutterdec_adapter::FunctionInfo,
+    class_to_library: &HashMap<String, String>,
+) -> String {
+    let library_uri = class_to_library
+        .get(&func.owner_class)
+        .map(String::as_str)
+        .unwrap_or("");
+    if library_uri.is_empty() {
+        return format!("{}::{}", func.owner_class, func.name);
+    }
+    format!("{}::{}::{}", library_uri, func.owner_class, func.name)
+}
+
+fn collect_function_descriptors(model: &ProgramModel) -> BTreeSet<String> {
+    let class_to_library = build_class_library_lookup(model);
+    model
+        .functions
+        .iter()
+        .map(|func| function_descriptor(func, &class_to_library))
+        .collect::<BTreeSet<_>>()
+}
+
+pub fn run_diff(
+    repo_root: &Path,
+    old_input_path: &Path,
+    new_input_path: &Path,
+    opt: &DiffOptions,
+) -> Result<DiffReport> {
+    let old_bundle = load_snapshot_bundle(old_input_path)?;
+    let new_bundle = load_snapshot_bundle(new_input_path)?;
+
+    let old_loaded = load_model(repo_root, &old_bundle, opt.adapter_backend)?;
+    let new_loaded = load_model(repo_root, &new_bundle, opt.adapter_backend)?;
+    let old_model = old_loaded.model;
+    let new_model = new_loaded.model;
+
+    let (old_scoped, _) =
+        apply_function_scope_filter(&old_model, opt.function_scope, &opt.app_packages);
+    let (new_scoped, _) =
+        apply_function_scope_filter(&new_model, opt.function_scope, &opt.app_packages);
+
+    let old_descriptors = collect_function_descriptors(&old_scoped);
+    let new_descriptors = collect_function_descriptors(&new_scoped);
+
+    let added = new_descriptors
+        .difference(&old_descriptors)
+        .cloned()
+        .collect::<Vec<_>>();
+    let removed = old_descriptors
+        .difference(&new_descriptors)
+        .cloned()
+        .collect::<Vec<_>>();
+    let common_count = old_descriptors
+        .intersection(&new_descriptors)
+        .count();
+
+    fs::create_dir_all(&opt.out_dir)?;
+    let report_path = opt.out_dir.join("diff_report.json");
+
+    let report = DiffReport {
+        old_input_path: old_bundle.input_path.display().to_string(),
+        new_input_path: new_bundle.input_path.display().to_string(),
+        old_snapshot_hash: old_bundle.snapshot_hash,
+        new_snapshot_hash: new_bundle.snapshot_hash,
+        old_dart_version: old_model.dart_version,
+        new_dart_version: new_model.dart_version,
+        function_scope: opt.function_scope.as_str().to_string(),
+        app_packages: opt.app_packages.clone(),
+        old_function_count: old_descriptors.len(),
+        new_function_count: new_descriptors.len(),
+        common_function_count: common_count,
+        added_function_count: added.len(),
+        removed_function_count: removed.len(),
+        added_functions_top: added.iter().take(200).cloned().collect::<Vec<_>>(),
+        removed_functions_top: removed.iter().take(200).cloned().collect::<Vec<_>>(),
+        report_path: report_path.display().to_string(),
+    };
+    fs::write(&report_path, serde_json::to_vec_pretty(&report)?)?;
+    Ok(report)
 }
 
 pub fn run_decompile(

--- a/crates/flutterdec-core/src/pipeline/runners/tests.rs
+++ b/crates/flutterdec-core/src/pipeline/runners/tests.rs
@@ -318,6 +318,53 @@
     }
 
     #[test]
+    fn collects_function_descriptors_with_library_context() {
+        let model = ProgramModel {
+            schema_version: 3,
+            adapter_kind: "python".to_string(),
+            dart_version: "unknown".to_string(),
+            snapshot_hash: "deadbeef".to_string(),
+            arch: "arm64".to_string(),
+            libraries: vec![flutterdec_adapter::LibraryInfo {
+                id: 0,
+                uri: "package:spotube/main.dart".to_string(),
+                name_display: "package:spotube/main.dart".to_string(),
+            }],
+            classes: vec![flutterdec_adapter::ClassInfo {
+                id: 0,
+                name: "Global".to_string(),
+                super_name: "Object".to_string(),
+                library_uri: "package:spotube/main.dart".to_string(),
+            }],
+            functions: vec![
+                flutterdec_adapter::FunctionInfo {
+                    id: 0,
+                    name: "main".to_string(),
+                    owner_class: "Global".to_string(),
+                    entry_va: 0x1000,
+                    size: 16,
+                    code_section_va: 0x1000,
+                    name_kind: Some("heuristic".to_string()),
+                },
+                flutterdec_adapter::FunctionInfo {
+                    id: 1,
+                    name: "sub_2000".to_string(),
+                    owner_class: "UnknownOwner".to_string(),
+                    entry_va: 0x2000,
+                    size: 16,
+                    code_section_va: 0x1000,
+                    name_kind: Some("placeholder".to_string()),
+                },
+            ],
+            object_pool: Vec::new(),
+        };
+
+        let descriptors = collect_function_descriptors(&model);
+        assert!(descriptors.contains("package:spotube/main.dart::Global::main"));
+        assert!(descriptors.contains("UnknownOwner::sub_2000"));
+    }
+
+    #[test]
     fn resolves_backend_from_adapter_kind_values() {
         assert_eq!(
             resolved_backend_from_adapter_kind("blutter_bridge_model_v1"),

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -80,6 +80,27 @@ Adapter backend environment:
 - `FLUTTERDEC_BLUTTER_CMD`: full command to execute Blutter bridge backend
 - `FLUTTERDEC_BLUTTER_PY`: path to `blutter.py` (uses current Python interpreter)
 
+## `flutterdec diff`
+
+Usage:
+
+```bash
+flutterdec diff --old <OLD_INPUT> --new <NEW_INPUT> -o <OUT_DIR> [OPTIONS]
+```
+
+Required:
+
+- `--old <OLD_INPUT>`: APK or `libapp.so` baseline
+- `--new <NEW_INPUT>`: APK or `libapp.so` candidate
+- `-o, --out <OUT_DIR>`
+
+Options:
+
+- `--function-scope <app-unknown|app|all>` (default `app-unknown`)
+- `--app-package <NAME>` (repeatable; limit compare set to selected app packages)
+- `--adapter-backend <auto|internal|blutter>` (default `auto`)
+- `--json`
+
 ## `flutterdec engine-fingerprint`
 
 Usage:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -124,6 +124,12 @@ Decompile with extra artifacts:
 flutterdec decompile ./sample.apk -o ./out --emit-asm --emit-ir
 ```
 
+Compare two builds at recovered-function level:
+
+```bash
+flutterdec diff --old ./old.apk --new ./new.apk -o ./out-diff --json
+```
+
 Include raw opcode words in asm output:
 
 ```bash
@@ -223,6 +229,7 @@ Written under output directory:
 - `pseudocode/*.dartpseudo`
 - `quality.json`
 - `report.json`
+- `diff_report.json` with `flutterdec diff`
 - `asm/*.s` with `--emit-asm`
 - opcode-prefixed asm lines with `--emit-asm --emit-asm-opcodes`
 - `ghidra_apply_symbols.py` with `--emit-ghidra-script` (symbol names + pool load comments)


### PR DESCRIPTION
## Summary
- add flutterdec diff to compare two APK/libapp inputs by recovered function descriptors
- emit diff_report.json with added/removed/common counts and top changes
- support existing scope controls (--function-scope, --app-package) and backend selection for consistency with decompile
- document the command in README, user guide, and CLI reference

## Validation
- nix develop -c ./scripts/ci-check.sh
- nix develop -c cargo run -q -p flutterdec-cli -- diff --old /tmp/flutterdec-apk-test/localsend.apk --new /tmp/flutterdec-apk-test/spotube.apk -o /tmp/flutterdec-diff-smoke --json