### PR TITLE
ci(tests): add full test suite workflow

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,41 @@
+name: Full Test Suite
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: full-test-suite-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  tests:
+    name: Full Test Suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - name: Run full test suite
+        run: ./scripts/test-suite.sh

--- a/scripts/test-suite.sh
+++ b/scripts/test-suite.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/test-suite.sh
+
+Runs the full Rust test suite from the workspace:
+  1) cargo test --workspace --all-targets
+  2) cargo test --workspace --release
+USAGE
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+cd "$repo_root"
+
+echo "[test-suite] cargo test --workspace --all-targets"
+nix develop -c cargo test --workspace --all-targets
+
+echo "[test-suite] cargo test --workspace --release"
+nix develop -c cargo test --workspace --release
+
+echo "[test-suite] all tests passed"


### PR DESCRIPTION
## Summary
- add a dedicated full test suite workflow for Linux and macOS
- add scripts/test-suite.sh as the shared entrypoint for the full Rust test suite
- keep this separate from the lighter CI checks workflow

## Testing
- nix run nixpkgs#actionlint -- .github/workflows/test-suite.yml .github/workflows/ci.yml .github/workflows/release.yml
- nix develop -c bash ./scripts/test-suite.sh