### PR TITLE
feat(cli): make --help self-documenting

### DIFF
--- a/context.md
+++ b/context.md
@@ -333,7 +333,7 @@ Python remains useful at the adapter boundary for faster version specific parser
 - refresh decompiler golden snapshots with `FLUTTERDEC_UPDATE_GOLDEN=1 cargo test -p flutterdec-decompiler golden_` when output changes intentionally
 - for end-to-end real binary regression checks, use `scripts/real-golden.sh record|check` for single profiles, or `scripts/real-golden-matrix.sh check` for multi-profile runs; those baselines now include `report_metrics.json` so startup, bootflow, entrypoint, and engine-symbol-ingestion deltas are diffed directly
 - keep profile configs in `testdata/real-golden/profiles/*/profile.env`
-- for naming improvements on direct call targets, use `map-symbols` on stripped/unstripped ELF pairs, then pass `decompile --extra-symbol-map-targets /path/to/symbol_target_summary.json`
+- for naming improvements on direct call targets, use `map-symbols` on stripped/unstripped ELF pairs, then pass `decompile --extra-symbol-map-target /path/to/symbol_target_summary.json`
 - `decompile` prefers external descriptive names over generic internal names (`sub_*`, `fn_0x*`) when addresses match
 - test against real Flutter binaries, not only synthetic fixtures
 - prioritize output readability improvements that are backed by concrete sample evidence

--- a/crates/flutterdec-cli/src/main.rs
+++ b/crates/flutterdec-cli/src/main.rs
@@ -143,9 +143,8 @@ written to report.json under target_selection."
         long_help = "\
 Which functions to include.
 
-  app-unknown  app (package:*) plus functions of unknown ownership [default]
-  app          only app (package:*) functions
-  all          also include Flutter, Dart runtime, and framework internals"
+Scope filters apply to every emitted artifact. Use --app-package to narrow
+further within a scope."
     )]
     function_scope: FunctionScopeArg,
     /// Restrict to this Dart package, as in package:<NAME>/... (repeatable)
@@ -166,12 +165,9 @@ Which functions to include.
         long_help = "\
 Which snapshot adapter backend to use.
 
-  auto      try the Blutter bridge when configured, else the internal adapter
-  internal  force the internal adapter
-  blutter   require the Blutter bridge, with no fallback
-
-The Blutter bridge is located via FLUTTERDEC_BLUTTER_CMD (a full command) or
-FLUTTERDEC_BLUTTER_PY (a path to blutter.py)."
+Backends are located through the environment: FLUTTERDEC_R2FLUTTER_BIN or
+FLUTTERDEC_R2FLUTTER_CMD for r2flutter, and FLUTTERDEC_BLUTTER_CMD or
+FLUTTERDEC_BLUTTER_PY for the Blutter bridge."
     )]
     adapter_backend: AdapterBackendArg,
     /// Fail if the adapter and loader disagree on the snapshot hash
@@ -186,9 +182,6 @@ FLUTTERDEC_BLUTTER_PY (a path to blutter.py)."
         help_heading = "Analysis engine",
         long_help = "\
 Analysis depth versus throughput.
-
-  balanced  best readability and semantic recovery [default]
-  light     reduced analysis, for faster large-scale runs
 
 Individual passes can be forced on or off with the --with-*/--no-* flags,
 which override whichever profile is selected."
@@ -320,7 +313,9 @@ struct DiffCmd {
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum AnalysisProfileArg {
+    /// Reduced analysis, for faster large-scale runs
     Light,
+    /// Best readability and semantic recovery
     Balanced,
 }
 
@@ -335,10 +330,13 @@ impl AnalysisProfileArg {
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum FunctionScopeArg {
+    /// App (package:*) plus functions of unknown ownership
     #[value(name = "app-unknown")]
     AppUnknown,
+    /// Only app (package:*) functions
     #[value(name = "app")]
     App,
+    /// Also include Flutter, Dart runtime, and framework internals
     #[value(name = "all")]
     All,
 }
@@ -355,11 +353,15 @@ impl FunctionScopeArg {
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 enum AdapterBackendArg {
+    /// Try r2flutter, then the Blutter bridge, then the internal adapter
     Auto,
+    /// Force the internal adapter
     Internal,
+    /// Require the Blutter bridge, with no fallback
     Blutter,
-    /// Spelled `r2-flutter` by clap's derive; accept the tool's own spelling too, since
-    /// that is what the docs, `report.json` and the env vars all call it.
+    // Clap's derive spells this value `r2-flutter`; the alias accepts the tool's own
+    // spelling, which is what the docs, `report.json` and the env vars all use.
+    /// Require the r2flutter backend, with no fallback
     #[value(alias = "r2flutter")]
     R2Flutter,
 }

--- a/crates/flutterdec-cli/src/main.rs
+++ b/crates/flutterdec-cli/src/main.rs
@@ -11,7 +11,28 @@ use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
 #[command(name = "flutterdec")]
-#[command(about = "Static Flutter AOT decompiler research CLI", long_about = None)]
+#[command(version)]
+#[command(propagate_version = true)]
+#[command(arg_required_else_help = true)]
+#[command(about = "Static Flutter AOT decompiler research CLI")]
+#[command(long_about = "\
+Static analysis and decompilation of Flutter AOT Android ARM64 binaries.
+
+Accepts an APK or a bare libapp.so. All analysis is static; the target is
+never executed.
+
+Typical flow:
+  1. flutterdec info <APK>                    inspect the target
+  2. flutterdec adapter install --dart-hash <HASH>  install the matching adapter
+  3. flutterdec decompile <APK> -o <DIR>      recover pseudocode")]
+#[command(after_help = "\
+Examples:
+  flutterdec info ./sample.apk --json
+  flutterdec decompile ./sample.apk -o ./out
+  flutterdec decompile ./sample.apk -o ./out --emit-asm --emit-ir
+  flutterdec diff --old ./old.apk --new ./new.apk -o ./out-diff --json
+
+Full reference: https://github.com/caverav/flutterdec/blob/main/docs/cli-reference.md")]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -19,108 +40,280 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    /// Inspect a target and report snapshot, arch, and adapter status
     Info(InfoCmd),
+    /// Recover Dart pseudocode from a Flutter AOT snapshot
     Decompile(DecompileCmd),
+    /// Compare two builds at recovered-function level
     Diff(DiffCmd),
+    /// Identify the Flutter engine build from an ELF
     EngineFingerprint(EngineFingerprintCmd),
+    /// Derive engine symbol names from a stripped/unstripped pair
     MapSymbols(MapSymbolsCmd),
+    /// Manage Dart snapshot adapters
     Adapter(AdapterCmd),
 }
 
 #[derive(Args, Debug)]
 struct InfoCmd {
+    /// APK or libapp.so to inspect
+    #[arg(value_name = "INPUT")]
     input: PathBuf,
+    /// Print the full report as JSON instead of plain text
     #[arg(long)]
     json: bool,
 }
 
 #[derive(Args, Debug)]
 struct DecompileCmd {
+    /// APK or libapp.so to decompile
+    #[arg(value_name = "INPUT")]
     input: PathBuf,
-    #[arg(short = 'o', long = "out")]
+    /// Directory to write pseudocode, reports, and artifacts into
+    #[arg(short = 'o', long = "out", value_name = "DIR")]
     out_dir: PathBuf,
-    #[arg(long)]
+
+    /// Write per-function ARM64 disassembly to asm/*.s
+    #[arg(long, help_heading = "Emitted artifacts")]
     emit_asm: bool,
-    #[arg(long)]
+    /// Prefix asm lines with raw 32-bit opcode words (requires --emit-asm)
+    #[arg(long, help_heading = "Emitted artifacts")]
     emit_asm_opcodes: bool,
-    #[arg(long)]
+    /// Write ghidra_apply_symbols.py to apply recovered symbols in Ghidra
+    #[arg(long, help_heading = "Emitted artifacts")]
     emit_ghidra_script: bool,
-    #[arg(long)]
+    /// Write ida_apply_symbols.py to apply recovered symbols in IDA
+    #[arg(long, help_heading = "Emitted artifacts")]
     emit_ida_script: bool,
-    #[arg(long)]
+    /// Write the intermediate representation to ir/*.json
+    #[arg(long, help_heading = "Emitted artifacts")]
     emit_ir: bool,
-    #[arg(long = "extra-symbol-elf")]
+
+    /// Unstripped engine ELF to harvest symbol names from (repeatable)
+    #[arg(
+        long = "extra-symbol-elf",
+        value_name = "PATH",
+        help_heading = "Symbol ingestion"
+    )]
     extra_symbol_elfs: Vec<PathBuf>,
-    #[arg(long = "extra-symbol-map-targets")]
+    /// Target summary produced by `map-symbols` to ingest (repeatable)
+    #[arg(
+        long = "extra-symbol-map-target",
+        alias = "extra-symbol-map-targets",
+        value_name = "PATH",
+        help_heading = "Symbol ingestion"
+    )]
     extra_symbol_map_targets: Vec<PathBuf>,
-    #[arg(long = "include-nearest-symbol-map")]
+    /// Fall back to the nearest preceding symbol when no exact match exists
+    #[arg(long, help_heading = "Symbol ingestion")]
     include_nearest_symbol_map: bool,
-    #[arg(long)]
+
+    /// Only process functions whose name contains this substring
+    #[arg(long, value_name = "SUBSTRING", help_heading = "Function selection")]
     focus: Option<String>,
-    #[arg(long = "target")]
+    /// Select one function: id:<N>, va:0x<ADDR>, 0x<ADDR>, or <N>
+    #[arg(
+        long,
+        value_name = "SELECTOR",
+        help_heading = "Function selection",
+        long_help = "\
+Restrict output to a single function.
+
+Accepted selectors:
+  id:<N>        function id, e.g. id:42
+  va:0x<ADDR>   entry virtual address, e.g. va:0x613468
+  0x<ADDR>      bare hex address
+  <N>           bare number; fails if it matches both an id and an address
+
+If the match falls outside the current --function-scope filter, target mode
+overrides the scope to keep the explicit match. Selection diagnostics are
+written to report.json under target_selection."
+    )]
     target: Option<String>,
-    #[arg(long)]
+    /// Stop after this many functions
+    #[arg(long, value_name = "N", help_heading = "Function selection")]
     max_functions: Option<usize>,
-    #[arg(long, default_value_t = 0)]
-    max_placeholder_ifs: usize,
-    #[arg(long, default_value_t = 0)]
-    max_unresolved_cf: usize,
-    #[arg(long, default_value_t = 0.30)]
-    max_indirect_call_ratio: f64,
-    #[arg(long, default_value_t = 0.80)]
-    min_disassembly_ratio: f64,
-    #[arg(long, value_enum, default_value_t = FunctionScopeArg::AppUnknown)]
+    /// Which functions to include
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = FunctionScopeArg::AppUnknown,
+        value_name = "SCOPE",
+        help_heading = "Function selection",
+        long_help = "\
+Which functions to include.
+
+  app-unknown  app (package:*) plus functions of unknown ownership [default]
+  app          only app (package:*) functions
+  all          also include Flutter, Dart runtime, and framework internals"
+    )]
     function_scope: FunctionScopeArg,
-    #[arg(long = "app-package")]
+    /// Restrict to this Dart package, as in package:<NAME>/... (repeatable)
+    #[arg(
+        long = "app-package",
+        value_name = "NAME",
+        help_heading = "Function selection"
+    )]
     app_packages: Vec<String>,
-    #[arg(long, value_enum, default_value_t = AdapterBackendArg::Auto)]
+
+    /// Which snapshot adapter backend to use
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = AdapterBackendArg::Auto,
+        value_name = "BACKEND",
+        help_heading = "Analysis engine",
+        long_help = "\
+Which snapshot adapter backend to use.
+
+  auto      try the Blutter bridge when configured, else the internal adapter
+  internal  force the internal adapter
+  blutter   require the Blutter bridge, with no fallback
+
+The Blutter bridge is located via FLUTTERDEC_BLUTTER_CMD (a full command) or
+FLUTTERDEC_BLUTTER_PY (a path to blutter.py)."
+    )]
     adapter_backend: AdapterBackendArg,
-    #[arg(long)]
+    /// Fail if the adapter and loader disagree on the snapshot hash
+    #[arg(long, help_heading = "Analysis engine")]
     require_snapshot_hash_match: bool,
-    #[arg(long, value_enum, default_value_t = AnalysisProfileArg::Balanced)]
+    /// Analysis depth versus throughput
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = AnalysisProfileArg::Balanced,
+        value_name = "PROFILE",
+        help_heading = "Analysis engine",
+        long_help = "\
+Analysis depth versus throughput.
+
+  balanced  best readability and semantic recovery [default]
+  light     reduced analysis, for faster large-scale runs
+
+Individual passes can be forced on or off with the --with-*/--no-* flags,
+which override whichever profile is selected."
+    )]
     analysis_profile: AnalysisProfileArg,
-    #[arg(long)]
+
+    /// Fail if more than N placeholder `if` statements are emitted
+    #[arg(
+        long,
+        default_value_t = 0,
+        value_name = "N",
+        help_heading = "Quality gates"
+    )]
+    max_placeholder_ifs: usize,
+    /// Fail if more than N control-flow edges stay unresolved
+    #[arg(
+        long,
+        default_value_t = 0,
+        value_name = "N",
+        help_heading = "Quality gates"
+    )]
+    max_unresolved_cf: usize,
+    /// Fail if the indirect-call ratio exceeds this fraction
+    #[arg(
+        long,
+        default_value_t = 0.30,
+        value_name = "RATIO",
+        help_heading = "Quality gates"
+    )]
+    max_indirect_call_ratio: f64,
+    /// Fail if the successfully disassembled fraction falls below this
+    #[arg(
+        long,
+        default_value_t = 0.80,
+        value_name = "RATIO",
+        help_heading = "Quality gates"
+    )]
+    min_disassembly_ratio: f64,
+
+    /// Force canonical model symbol naming on
+    #[arg(
+        long,
+        conflicts_with = "no_canonical_model_symbols",
+        help_heading = "Analysis passes"
+    )]
     with_canonical_model_symbols: bool,
-    #[arg(long)]
+    /// Force canonical model symbol naming off
+    #[arg(long, help_heading = "Analysis passes")]
     no_canonical_model_symbols: bool,
-    #[arg(long)]
+    /// Force object-pool value hints on
+    #[arg(
+        long,
+        conflicts_with = "no_pool_value_hints",
+        help_heading = "Analysis passes"
+    )]
     with_pool_value_hints: bool,
-    #[arg(long)]
+    /// Force object-pool value hints off
+    #[arg(long, help_heading = "Analysis passes")]
     no_pool_value_hints: bool,
-    #[arg(long)]
+    /// Force object-pool semantic hints on
+    #[arg(
+        long,
+        conflicts_with = "no_pool_semantic_hints",
+        help_heading = "Analysis passes"
+    )]
     with_pool_semantic_hints: bool,
-    #[arg(long)]
+    /// Force object-pool semantic hints off
+    #[arg(long, help_heading = "Analysis passes")]
     no_pool_semantic_hints: bool,
-    #[arg(long)]
+    /// Force semantic reporting on
+    #[arg(
+        long,
+        conflicts_with = "no_semantic_reporting",
+        help_heading = "Analysis passes"
+    )]
     with_semantic_reporting: bool,
-    #[arg(long)]
+    /// Force semantic reporting off
+    #[arg(long, help_heading = "Analysis passes")]
     no_semantic_reporting: bool,
-    #[arg(long)]
+    /// Force boot-flow category seeding on
+    #[arg(
+        long,
+        conflicts_with = "no_bootflow_category_seeds",
+        help_heading = "Analysis passes"
+    )]
     with_bootflow_category_seeds: bool,
-    #[arg(long)]
+    /// Force boot-flow category seeding off
+    #[arg(long, help_heading = "Analysis passes")]
     no_bootflow_category_seeds: bool,
-    #[arg(long)]
+    /// Force APK startup analysis on
+    #[arg(
+        long,
+        conflicts_with = "no_apk_startup_analysis",
+        help_heading = "Analysis passes"
+    )]
     with_apk_startup_analysis: bool,
-    #[arg(long)]
+    /// Force APK startup analysis off
+    #[arg(long, help_heading = "Analysis passes")]
     no_apk_startup_analysis: bool,
 }
 
 #[derive(Args, Debug)]
 struct DiffCmd {
-    #[arg(long = "old")]
+    /// Baseline APK or libapp.so
+    #[arg(long = "old", value_name = "INPUT")]
     old_input: PathBuf,
-    #[arg(long = "new")]
+    /// Candidate APK or libapp.so to compare against the baseline
+    #[arg(long = "new", value_name = "INPUT")]
     new_input: PathBuf,
-    #[arg(short = 'o', long = "out")]
+    /// Directory to write diff_report.json into
+    #[arg(short = 'o', long = "out", value_name = "DIR")]
     out_dir: PathBuf,
-    #[arg(long, value_enum, default_value_t = FunctionScopeArg::AppUnknown)]
+    /// Which functions to compare [app-unknown, app, all]
+    #[arg(long, value_enum, default_value_t = FunctionScopeArg::AppUnknown, value_name = "SCOPE")]
     function_scope: FunctionScopeArg,
-    #[arg(long = "app-package")]
+    /// Restrict the compare set to this Dart package (repeatable)
+    #[arg(long = "app-package", value_name = "NAME")]
     app_packages: Vec<String>,
-    #[arg(long, value_enum, default_value_t = AdapterBackendArg::Auto)]
+    /// Which snapshot adapter backend to use
+    #[arg(long, value_enum, default_value_t = AdapterBackendArg::Auto, value_name = "BACKEND")]
     adapter_backend: AdapterBackendArg,
+    /// Fail if either side has an adapter/loader snapshot hash mismatch
     #[arg(long)]
     require_snapshot_hash_match: bool,
+    /// Print the diff summary as JSON on stdout
     #[arg(long)]
     json: bool,
 }
@@ -184,44 +377,60 @@ impl AdapterBackendArg {
 
 #[derive(Args, Debug)]
 struct EngineFingerprintCmd {
+    /// Engine ELF to fingerprint, usually libflutter.so
+    #[arg(value_name = "INPUT")]
     input: PathBuf,
-    #[arg(short = 'o', long = "out")]
+    /// Directory to write the fingerprint report into
+    #[arg(short = 'o', long = "out", value_name = "DIR")]
     out_dir: Option<PathBuf>,
-    #[arg(long, default_value_t = 24)]
+    /// Maximum number of version markers to report
+    #[arg(long, default_value_t = 24, value_name = "N")]
     max_markers: usize,
+    /// Print the fingerprint as JSON on stdout
     #[arg(long)]
     json: bool,
 }
 
 #[derive(Args, Debug)]
 struct MapSymbolsCmd {
-    #[arg(long = "stripped")]
+    /// Stripped engine ELF, matching the one shipped in the APK
+    #[arg(long = "stripped", value_name = "PATH")]
     stripped_path: PathBuf,
-    #[arg(long = "unstripped")]
+    /// Unstripped build of the same engine, carrying the symbol names
+    #[arg(long = "unstripped", value_name = "PATH")]
     unstripped_path: PathBuf,
-    #[arg(short = 'o', long = "out")]
+    /// Directory to write the symbol map into
+    #[arg(short = 'o', long = "out", value_name = "DIR")]
     out_dir: PathBuf,
+    /// Also map branch targets, not just call targets
     #[arg(long)]
     include_branches: bool,
-    #[arg(long, default_value_t = 8192)]
+    /// Maximum byte distance when falling back to the nearest symbol
+    #[arg(long, default_value_t = 8192, value_name = "BYTES")]
     nearest_max_distance: u64,
+    /// Require executable-section layout to match between the two ELFs
     #[arg(long)]
     require_exec_match: bool,
+    /// Register the result in symbols/manifest.json for later auto-ingestion
     #[arg(long = "register-local-cache")]
     register_local_cache: bool,
+    /// Print the mapping summary as JSON on stdout
     #[arg(long)]
     json: bool,
 }
 
 #[derive(Subcommand, Debug)]
 enum AdapterSubcommand {
+    /// Build and install the adapter for a given Dart snapshot hash
     Install(AdapterInstallCmd),
+    /// List known adapters and whether each is installed
     List,
 }
 
 #[derive(Args, Debug)]
 struct AdapterInstallCmd {
-    #[arg(long = "dart-hash")]
+    /// Dart snapshot hash, as reported by `flutterdec info`
+    #[arg(long = "dart-hash", value_name = "HASH")]
     dart_hash: String,
 }
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,8 @@
 # CLI Reference
 
+`flutterdec --help` is the quickest overview. Use `flutterdec <COMMAND> --help`
+for command-specific options. The current release is `0.1.0-alpha.2`.
+
 ## `flutterdec info`
 
 Usage:
@@ -59,9 +62,8 @@ General options:
 - `--require-snapshot-hash-match` (fail if adapter-reported snapshot hash differs from loader hash)
 
 Symbol ingestion:
-
+- `--extra-symbol-map-target <PATH>` (repeatable; `--extra-symbol-map-targets` remains accepted as an alias)
 - `--extra-symbol-elf <PATH>` (repeatable)
-- `--extra-symbol-map-targets <PATH>` (repeatable)
 - `--include-nearest-symbol-map`
 
 Quality-gate options:

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -785,7 +785,7 @@ Symptom: pseudocode has too many omitted path summaries
 Symptom: function names are too synthetic
 
 - improve adapter metadata extraction first
-- then run `map-symbols` on stripped/unstripped pairs and either feed `symbol_target_summary.json` into `decompile --extra-symbol-map-targets ...` or register it into the local cache with `--register-local-cache`
+- then run `map-symbols` on stripped/unstripped pairs and either feed `symbol_target_summary.json` into `decompile --extra-symbol-map-target ...` or register it into the local cache with `--register-local-cache`
 
 Symptom: control flow is valid but hard to read
 


### PR DESCRIPTION
## Summary

`flutterdec --help` shipped effectively blank. `--version` did not exist at all, and all 40 `decompile` flags rendered with empty descriptions:

```
      --emit-asm

      --emit-asm-opcodes

      --extra-symbol-elf <EXTRA_SYMBOL_ELFS>

```

Every one of those descriptions **already existed** in `docs/cli-reference.md`. The knowledge was written down but unreachable from the terminal, so the doc and the binary had drifted in usefulness even though they had not drifted in accuracy. This PR ports the reference doc into clap so the binary documents itself.

### CLI

- Add `--version`. Previously `flutterdec --version` returned `error: unexpected argument '--version' found`.
- Show full help on a bare invocation instead of a terse usage error.
- Describe every subcommand, positional, and flag.
- Group the 40 `decompile` flags under six headings mirroring the reference doc: Emitted artifacts, Symbol ingestion, Function selection, Analysis engine, Quality gates, Analysis passes.
- Add value names (`<DIR>`, `<PATH>`, `<N>`, `<SCOPE>`), replacing leaked Rust field names like `<EXTRA_SYMBOL_ELFS>`.
- Document `--target` selectors in long help.
- Declare `--with-*` / `--no-*` conflicts in clap, so they are rejected at parse time with a standard message and the relationship is visible in help.
- Root help gains a typical-flow section, runnable examples, and a link to the reference.

### Value lists are generated, not hand-written

Rebasing onto #85 surfaced the drift this PR exists to prevent, so the second commit fixes the mechanism rather than the symptom.

#85 added an r2flutter backend. My hand-written `long_help` still listed three backends and described the old `auto` fallback chain. The merge was textually clean and nothing caught it, because #85 edited the enum while this PR edited a *string describing* the enum. Separately, adding `long_help` switched clap to its expanded value renderer, which surfaces variant doc comments — promoting #85's internal aside about clap's derive spelling into the user-facing description of `r2-flutter`.

Both are fixed at the source: per-value text moved onto the variants, `long_help` trimmed to what clap cannot derive.

```
      --adapter-backend <BACKEND>
          Which snapshot adapter backend to use.

          Backends are located through the environment: FLUTTERDEC_R2FLUTTER_BIN or
          FLUTTERDEC_R2FLUTTER_CMD for r2flutter, and FLUTTERDEC_BLUTTER_CMD or
          FLUTTERDEC_BLUTTER_PY for the Blutter bridge.

          Possible values:
          - auto:       Try r2flutter, then the Blutter bridge, then the internal adapter
          - internal:   Force the internal adapter
          - blutter:    Require the Blutter bridge, with no fallback
          - r2-flutter: Require the r2flutter backend, with no fallback
```

Applied to all three value enums. A new variant now documents itself. #85's derive-spelling note became a plain `//` comment, so it stays with the code without rendering as help.

### Standardization

`--extra-symbol-map-targets` was the only plural repeatable flag, inconsistent with its siblings `--extra-symbol-elf` and `--app-package`. It becomes singular `--extra-symbol-map-target`, with the plural retained as a clap alias so existing invocations keep working. Stale plural usages updated in `docs/how-it-works.md` and `context.md`.

### Deliberately unchanged

- **Runtime validation.** `--emit-asm-opcodes` keeps its runtime check instead of a clap `requires`, because `decompile_rejects_emit_asm_opcodes_without_emit_asm` asserts it *parses* and then fails during option building. Adding `requires` would break that test, and weakening a test to fit a change is the wrong trade.
- **`README.md` and `docs/user-guide.md`.** Audited every command example against the real binary; all already accurate and task-oriented.
- **`docs/cli-reference.md` backend lines.** #85 already documents all four backends, the `auto` chain, and the three `FLUTTERDEC_R2FLUTTER_*` env vars. Help now matches the doc.

No behavior changes beyond argument parsing.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (286 passed, 0 failed)
- [ ] Real-binary check completed (for decompiler behavior changes) — N/A, no decompiler changes

Additional verification:

- Help renders for all 9 command paths: root, `info`, `decompile`, `diff`, `engine-fingerprint`, `map-symbols`, `adapter`, `adapter install`, `adapter list`.
- `--extra-symbol-map-target` and the plural alias both parse; `r2flutter` and `r2-flutter` both parse.
- Conflict rejection confirmed: `error: the argument '--with-canonical-model-symbols' cannot be used with '--no-canonical-model-symbols'`.
- Repo-wide grep for the retired plural spelling returns only the alias declaration and its documentation line.

**Correction to an earlier revision of this description:** it claimed clippy failed on 5 pre-existing `flutterdec-decompiler` warnings. That was a local-toolchain artifact — my rustup stable is 1.97.1, while CI runs the same command inside `nix develop` against the flake-pinned toolchain, where those lints do not fire. CI's Rust Checks pass on both this branch and `main`. The box is checked accordingly.

## Scope

- [x] Atomic commits (`type(scope): description`)
- [x] Docs updated (`README.md`, `docs/*`, `context.md`) when behavior changed
- [x] No unrelated refactors mixed in
