### PR TITLE
chore(release): prepare v0.1.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-adapter"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-cli"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-core"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "capstone",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-decompiler"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "flutterdec-ir",
  "serde",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-disasm-arm64"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "capstone",
  "flutterdec-adapter",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-ir"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "flutterdec-disasm-arm64",
  "serde",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-loader"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "anyhow",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ nix profile upgrade flutterdec
 
 ### Install A Release Binary
 
-Current prerelease: [`v0.1.0-alpha.2`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.2)
+Current prerelease: [`v0.1.0-alpha.3`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.3)
 
 Linux x64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.2/flutterdec-v0.1.0-alpha.2-Linux-X64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.2-Linux-X64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```
@@ -93,8 +93,8 @@ flutterdec --help
 macOS arm64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.2/flutterdec-v0.1.0-alpha.2-macOS-ARM64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.2-macOS-ARM64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,7 +1,8 @@
 # CLI Reference
 
-`flutterdec --help` is the quickest overview. Use `flutterdec <COMMAND> --help`
-for command-specific options. The current release is `0.1.0-alpha.2`.
+This reference describes the CLI at the current commit. `flutterdec --help` is
+the quickest overview, `flutterdec <COMMAND> --help` covers a single command,
+and `flutterdec --version` reports the build you are running.
 
 ## `flutterdec info`
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -62,13 +62,13 @@ nix profile upgrade flutterdec
 
 ### Install From A Release Binary
 
-Current prerelease: [`v0.1.0-alpha.2`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.2)
+Current prerelease: [`v0.1.0-alpha.3`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.3)
 
 Linux x64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.2/flutterdec-v0.1.0-alpha.2-Linux-X64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.2-Linux-X64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```
@@ -76,8 +76,8 @@ flutterdec --help
 macOS arm64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.2/flutterdec-v0.1.0-alpha.2-macOS-ARM64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.2-macOS-ARM64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```


### PR DESCRIPTION
## Summary

Version bump for the next prerelease. 26 commits since `v0.1.0-alpha.2` (2026-03-14), 62 files, +3872/-425.

Bumps `Cargo.toml`, `Cargo.lock`, and the pinned download URLs in `README.md` and `docs/user-guide.md`.

Also drops the hand-written `The current release is 0.1.0-alpha.2` line I added to `docs/cli-reference.md` in #87. It duplicated `--version`, described the *tag* rather than the commit the doc actually sits on, and had to be remembered on every release. It now states it describes the current commit and points at `--version`.

`flake.nix` keeps `version = "0.1.0"` — coarse by design, unchanged across both prior prereleases.

### What is in this release

**Correctness**

- #85 — object pool references resolved in the real index space. `ldr xN, [x27, #disp]` was annotated `pool[disp]`, treating a raw byte displacement as an entry index; the correct entry is `(disp - entries_offset) / word_size`. The bad index was then joined against `object_pool[].index`, so lookups landed on unrelated slots and **rendered string literals the binary never referenced**. Anyone comparing alpha.2 pseudocode against a real target should re-run.
- #72 — strict quality-gate failures now explain themselves instead of failing bare.
- #62 — simple helper returns propagate through startup analysis.

**Features**

- #85 — r2flutter adapter backend, `--adapter-backend r2-flutter` (alias `r2flutter`), with `auto` now trying r2flutter → blutter → internal.
- #87 — `--help` is self-documenting: `--version` now exists, all 40 `decompile` flags carry descriptions grouped under six headings, value lists are generated from enum variants.

**Performance**

- #59 — APK session shared across the pipeline instead of reopened per stage.

**CI and packaging**

- #67 full test suite workflow, #58 node24 runtime, #57 prerelease auto-detection from the tag name, #66 explicit adapter subprocess shell mode.

**Docs**

- #65 onboarding and Nix install, #63 decompilation pipeline walkthrough.

**Dependencies**

- 15 Dependabot bumps: zip 8.1.0 → 8.6.0, serde 1.0.229, serde_json 1.0.150, regex 1.13.1, anyhow 1.0.104, goblin 0.10.7, tempfile 3.27.0, actions/checkout v7, softprops/action-gh-release v3, magic-nix-cache.

### Release mechanics

Tagging `v0.1.0-alpha.3` after merge triggers `.github/workflows/release.yml`: Linux x64 + macOS ARM64 artifacts, auto-generated notes, and `prerelease: true` inferred from the `-` in the tag.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (286 passed, 0 failed)
- [ ] Real-binary check completed (for decompiler behavior changes) — N/A, no behavior change in this PR

Additional verification:

- `flutterdec --version` reports `flutterdec 0.1.0-alpha.3`.
- All 7 workspace crates updated in `Cargo.lock`.
- `git grep alpha.2` over tracked files returns nothing outside `Cargo.lock` history.

## Scope

- [x] Atomic commits (`type(scope): description`)
- [x] Docs updated (`README.md`, `docs/*`, `context.md`) when behavior changed
- [x] No unrelated refactors mixed in
