### PR TITLE
fix(release): build portable artifacts outside the Nix dev shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,27 +13,61 @@ env:
 
 jobs:
   build:
-    name: Build Release (${{ matrix.os }})
+    name: Build Release (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: macos-latest
+            target: aarch64-apple-darwin
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      # Release artifacts are built with a plain toolchain, NOT `nix develop`.
+      # Building inside the dev shell links against /nix/store paths, which do
+      # not exist on user machines: every release up to v0.1.0-alpha.3 shipped
+      # a Linux binary whose ELF interpreter was a /nix/store glibc, and a
+      # macOS binary loading /nix/store libiconv. Both failed to start off Nix.
+      # CI checks still use Nix; only packaging is plain.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
 
-      - name: Enable Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Install musl tooling
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update -qq && sudo apt-get install -y musl-tools musl-dev
 
       - name: Build release CLI
-        run: nix develop -c cargo build -p flutterdec-cli --release
+        run: cargo build -p flutterdec-cli --release --target ${{ matrix.target }}
+
+      - name: Verify artifact is portable
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin="target/${{ matrix.target }}/release/flutterdec"
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            # musl static-pie: `file` reports "static-pie linked". Anything
+            # dynamic would name an ELF interpreter, which is exactly the
+            # /nix/store breakage this guard exists to catch.
+            if ! file "$bin" | grep -q 'static'; then
+              echo "::error::expected a static binary"
+              file "$bin"
+              exit 1
+            fi
+          else
+            if otool -L "$bin" | grep -q '/nix/store'; then
+              echo "::error::binary links against /nix/store"
+              otool -L "$bin"
+              exit 1
+            fi
+          fi
+          "$bin" --version
 
       - name: Package artifact
         shell: bash
@@ -43,9 +77,8 @@ jobs:
           arch="${{ runner.arch }}"
           out_dir="dist"
           mkdir -p "$out_dir"
-          bin_name="flutterdec"
           archive="$out_dir/flutterdec-${{ github.ref_name }}-${os}-${arch}.tar.gz"
-          tar -C target/release -czf "$archive" "$bin_name"
+          tar -C "target/${{ matrix.target }}/release" -czf "$archive" flutterdec
           echo "archive=$archive" >> "$GITHUB_ENV"
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary

**Every release this project has published is unusable on a machine without Nix.** Both platforms, going back at least to `v0.1.0-alpha.2`. I found this while verifying the `v0.1.0-alpha.3` artifacts I had just cut, after an HTTP 200 on the download URL turned out to prove nothing.

`nix develop -c cargo build` links against `/nix/store`, and the packaging step tarred the result unchanged.

**Linux** `v0.1.0-alpha.3` and `v0.1.0-alpha.2` are byte-identical in this respect:

```
interpreter /nix/store/wb6rhpznjfczwlwx23zmdrrw74bayxw4-glibc-2.42-47/lib/ld-linux-x86-64.so.2
RUNPATH     /home/runner/work/flutterdec/flutterdec/outputs/out/lib:
            /nix/store/wb6...-glibc-2.42-47/lib:/nix/store/j2k...-gcc-15.2.0-lib/lib
```

In a clean `ubuntu:22.04` container:

```
$ ./flutterdec --version
sh: 1: ./flutterdec: not found        # exit 127
```

That misleading `not found` is the kernel failing to load a `PT_INTERP` that does not exist. The RUNPATH additionally leaks the CI runner's working directory.

**macOS** same class of bug:

```
$ otool -L flutterdec
    /nix/store/7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2/lib/libiconv.2.dylib
    /usr/lib/libSystem.B.dylib
```

This one is especially easy to miss: it runs fine on any Mac that has Nix, which includes the machine that cuts the releases. I initially "verified" `alpha.3` on macOS this way and got a false pass.

Plain `cargo` on the same machine produces `/usr/lib/libiconv.2.dylib`, confirming the dev shell is the sole cause.

### Fix

Build release artifacts with a plain toolchain. CI *checks* keep using Nix for reproducibility; only *packaging* changes.

- **Linux -> `x86_64-unknown-linux-musl`**, static-pie. Capstone builds against musl without issue. No interpreter, no RUNPATH, no glibc floor.
- **macOS -> `aarch64-apple-darwin`**, which links the system libiconv.

A verify step now fails the build if the Linux artifact is not static or the macOS artifact mentions `/nix/store`, so this cannot regress silently.

Asset names are unchanged, so the URLs already documented in `README.md` and `docs/user-guide.md` stay correct.

## Validation

Static musl binary built from this tree and executed in three clean, non-Nix containers:

| Image | Result |
|---|---|
| `ubuntu:22.04` | `flutterdec 0.1.0-alpha.3` |
| `alpine:3` | `flutterdec 0.1.0-alpha.3` |
| `busybox:latest` | `flutterdec 0.1.0-alpha.3` |

```
$ file flutterdec
ELF 64-bit LSB pie executable, x86-64, static-pie linked, …
```

- [x] `cargo fmt --all --check` — unchanged, workflow-only diff
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (286 passed, 0 failed)
- [ ] Real-binary check — N/A, no decompiler change

The end-to-end proof is the release run itself: after merge I will re-cut `v0.1.0-alpha.3` and download the published assets into clean containers before calling it done.

## Follow-up

`v0.1.0-alpha.3` is currently published with broken artifacts. Since it is hours old and non-functional on both platforms, I intend to delete the tag and release and re-cut it from the fixed workflow rather than burn a version number on a release nobody can run. Flagging it explicitly because deleting a published tag is destructive.

## Scope

- [x] Atomic commits (`type(scope): description`)
- [x] Docs updated when behavior changed — asset names and URLs unchanged
- [x] No unrelated refactors mixed in
