### PR TITLE
chore(release): prepare v0.1.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-adapter"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-cli"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-core"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "capstone",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-decompiler"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "flutterdec-ir",
  "serde",
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-disasm-arm64"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "capstone",
  "flutterdec-adapter",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-ir"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "flutterdec-disasm-arm64",
  "serde",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "flutterdec-loader"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "goblin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 license = "MIT"
 

--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ nix profile upgrade flutterdec
 
 ### Install A Release Binary
 
-Current prerelease: [`v0.1.0-alpha.3`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.3)
+Current prerelease: [`v0.1.0-alpha.4`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.4)
 
 Linux x64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.4/flutterdec-v0.1.0-alpha.4-Linux-X64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.4-Linux-X64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```
@@ -93,8 +93,8 @@ flutterdec --help
 macOS arm64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.4/flutterdec-v0.1.0-alpha.4-macOS-ARM64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.4-macOS-ARM64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -62,13 +62,13 @@ nix profile upgrade flutterdec
 
 ### Install From A Release Binary
 
-Current prerelease: [`v0.1.0-alpha.3`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.3)
+Current prerelease: [`v0.1.0-alpha.4`](https://github.com/caverav/flutterdec/releases/tag/v0.1.0-alpha.4)
 
 Linux x64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.3-Linux-X64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.4/flutterdec-v0.1.0-alpha.4-Linux-X64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.4-Linux-X64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```
@@ -76,8 +76,8 @@ flutterdec --help
 macOS arm64:
 
 ```bash
-curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.3/flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
-tar -xzf flutterdec-v0.1.0-alpha.3-macOS-ARM64.tar.gz
+curl -fLO https://github.com/caverav/flutterdec/releases/download/v0.1.0-alpha.4/flutterdec-v0.1.0-alpha.4-macOS-ARM64.tar.gz
+tar -xzf flutterdec-v0.1.0-alpha.4-macOS-ARM64.tar.gz
 sudo install -m 0755 flutterdec /usr/local/bin/flutterdec
 flutterdec --help
 ```


### PR DESCRIPTION
## Summary

Version bump to `v0.1.0-alpha.4`, the first release whose binaries are built outside the Nix dev shell (#89).

### Why alpha.4 and not alpha.3

`v0.1.0-alpha.3` shipped binaries that could not start on any machine without Nix — Linux had a `/nix/store` ELF interpreter, macOS loaded `/nix/store` libiconv. It was withdrawn.

It is **not** being re-cut under the same version. A version number must identify exactly one build; re-tagging after assets were already published would make `alpha.3` ambiguous for anyone who cached it. Re-tagging would also have rebuilt the *broken* artifacts regardless, since tag-triggered runs read the workflow file at the tagged ref, and that commit predates #89.

So `alpha.3` is a deliberate gap in the sequence, and `alpha.4` carries the same source plus the workflow fix.

### Contents

Everything from the withdrawn alpha.3 — 26 commits since `v0.1.0-alpha.2` — plus #89.

**Correctness**

- #85 — object pool references resolved in the real index space. `ldr xN, [x27, #disp]` was annotated `pool[disp]`, treating a raw byte displacement as an entry index; the correct entry is `(disp - entries_offset) / word_size`. The bad index was joined against `object_pool[].index`, so lookups landed on unrelated slots and **rendered string literals the binary never referenced**. Anyone holding alpha.2 pseudocode should re-run.
- #72 — strict quality-gate failures explain themselves.
- #62 — simple helper returns propagate through startup analysis.

**Features**

- #85 — r2flutter adapter backend; `auto` now tries r2flutter → blutter → internal.
- #87 — self-documenting `--help`: `--version` now exists, all 40 `decompile` flags carry grouped descriptions, value lists generated from enum variants.

**Packaging**

- #89 — Linux is now a static-pie musl binary, macOS links system libiconv. A verify step fails the build if either regresses.

**Performance / CI / docs / deps**

- #59 shared APK session; #67, #58, #57, #66 CI and adapter hygiene; #65, #63 docs; 15 Dependabot bumps (zip 8.1.0 → 8.6.0, serde, serde_json, regex, anyhow, goblin, tempfile, actions/checkout v7, action-gh-release v3).

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (286 passed, 0 failed)
- [ ] Real-binary check — N/A, version bump only

`flutterdec --version` reports `flutterdec 0.1.0-alpha.4`; all 7 workspace crates updated in `Cargo.lock`; no `alpha.3` references remain in tracked files.

After merge I will tag `v0.1.0-alpha.4` and then **download the published assets into clean non-Nix containers** before calling the release done. That check is what caught this in the first place.

## Scope

- [x] Atomic commits (`type(scope): description`)
- [x] Docs updated (`README.md`, `docs/*`) when behavior changed
- [x] No unrelated refactors mixed in
