### PR TITLE
fix(cli): enable --adapter-backend for the info command

### DIFF
--- a/crates/flutterdec-cli/src/main.rs
+++ b/crates/flutterdec-cli/src/main.rs
@@ -62,6 +62,9 @@ struct InfoCmd {
     /// Print the full report as JSON instead of plain text
     #[arg(long)]
     json: bool,
+    /// Which snapshot adapter backend to use
+    #[arg(long, value_enum, default_value_t = AdapterBackendArg::Auto, value_name = "BACKEND")]
+    adapter_backend: AdapterBackendArg,
 }
 
 #[derive(Args, Debug)]
@@ -484,7 +487,7 @@ fn main() -> Result<()> {
 }
 
 fn handle_info(repo_root: &Path, cmd: InfoCmd) -> Result<()> {
-    let out = run_info(repo_root, &cmd.input)?;
+    let out = run_info(repo_root, &cmd.input, cmd.adapter_backend.to_core())?;
     if cmd.json {
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
@@ -1013,6 +1016,32 @@ mod tests {
         .expect("parse");
         let Command::Decompile(cmd) = cli.command else {
             panic!("expected decompile command");
+        };
+        assert!(matches!(cmd.adapter_backend, AdapterBackendArg::R2Flutter));
+        assert_eq!(cmd.adapter_backend.to_core().as_str(), "r2flutter");
+    }
+
+    #[test]
+    fn info_adapter_backend_defaults_to_auto() {
+        let cli = Cli::try_parse_from(["flutterdec", "info", "sample.apk"]).expect("parse");
+        let Command::Info(cmd) = cli.command else {
+            panic!("expected info command");
+        };
+        assert!(matches!(cmd.adapter_backend, AdapterBackendArg::Auto));
+    }
+
+    #[test]
+    fn info_adapter_backend_accepts_r2flutter() {
+        let cli = Cli::try_parse_from([
+            "flutterdec",
+            "info",
+            "in.apk",
+            "--adapter-backend",
+            "r2-flutter",
+        ])
+        .expect("parse");
+        let Command::Info(cmd) = cli.command else {
+            panic!("expected info command");
         };
         assert!(matches!(cmd.adapter_backend, AdapterBackendArg::R2Flutter));
         assert_eq!(cmd.adapter_backend.to_core().as_str(), "r2flutter");

--- a/crates/flutterdec-core/src/pipeline/runners.rs
+++ b/crates/flutterdec-core/src/pipeline/runners.rs
@@ -982,7 +982,11 @@ fn apply_function_scope_filter(
     (scoped, stats)
 }
 
-pub fn run_info(repo_root: &Path, input_path: &Path) -> Result<InfoOutput> {
+pub fn run_info(
+    repo_root: &Path,
+    input_path: &Path,
+    adapter_backend: AdapterBackend,
+) -> Result<InfoOutput> {
     let apk_session = open_apk_session_if_input_is_apk(input_path)?;
     let bundle = load_snapshot_bundle_with_optional_apk_session(input_path, apk_session.as_ref())?;
     let adapter_installed = resolve_adapter_exec(repo_root, &bundle.snapshot_hash).is_ok();
@@ -1035,12 +1039,20 @@ pub fn run_info(repo_root: &Path, input_path: &Path) -> Result<InfoOutput> {
     };
 
     if adapter_installed {
-        if let Ok(loaded) = load_model(repo_root, &bundle, AdapterBackend::Auto) {
+        if let Ok(loaded) = load_model(repo_root, &bundle, adapter_backend) {
             let manifest_entry_present = loaded.manifest_entry_adapter.is_some();
             let model = loaded.model;
             let snapshot_hash_match = bundle.snapshot_hash == model.snapshot_hash;
-            let warnings =
-                collect_compatibility_warnings(manifest_entry_present, snapshot_hash_match, false);
+            let resolved_backend = resolved_backend_from_adapter_kind(&model.adapter_kind);
+            let backend_mismatch = match adapter_backend {
+                AdapterBackend::Auto => false,
+                _ => resolved_backend.is_some_and(|value| value != adapter_backend),
+            };
+            let warnings = collect_compatibility_warnings(
+                manifest_entry_present,
+                snapshot_hash_match,
+                backend_mismatch,
+            );
             out.adapter_kind = Some(model.adapter_kind.clone());
             out.manifest_entry_present = Some(manifest_entry_present);
             out.adapter_snapshot_hash_match = Some(snapshot_hash_match);

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,13 +9,14 @@ and `flutterdec --version` reports the build you are running.
 Usage:
 
 ```bash
-flutterdec info <INPUT> [--json]
+flutterdec info <INPUT> [--json] [--adapter-backend <BACKEND>]
 ```
 
 Arguments:
 
 - `<INPUT>`: APK or `libapp.so`
 - `--json`: print JSON output
+- `--adapter-backend <auto|internal|blutter|r2-flutter>` (default `auto`; `auto` tries r2flutter, then blutter, then internal)
 
 Resolved from the snapshot hash alone, with or without an adapter, in both JSON and
 plain output:


### PR DESCRIPTION
## Problem

`info` had no `--adapter-backend` flag. `run_info` always called `load_model` with `AdapterBackend::Auto` hardcoded, so there was no way to force `internal`, `blutter`, or `r2-flutter` when inspecting a target, even though `decompile` and `diff` both already support the flag.

## Fix

- Added `--adapter-backend <auto|internal|blutter|r2-flutter>` to `InfoCmd`, matching the existing `decompile`/`diff` flag definition and default (`auto`).
- Threaded the value through `run_info(repo_root, input_path, adapter_backend)` into `load_model`.
- `run_info` previously hardcoded `backend_mismatch` to `false`, so the existing "resolved adapter backend differs from requested backend" warning could never fire for `info`. It now resolves the backend from `adapter_kind` and compares it against the requested backend, same logic already used by `run_decompile`.
- Documented the new flag in `docs/cli-reference.md`.

## Testing

- `cargo build -p flutterdec-core -p flutterdec-cli`
- `cargo test -p flutterdec-cli` (20 passed, including 2 new tests for the flag default and `r2-flutter` parsing)
- `cargo test -p flutterdec-core` (91 passed)
- `cargo run -p flutterdec-cli -- info --help` shows the new flag with its possible values and default
